### PR TITLE
Create signal handler to respond when BlockCompletions are updated 

### DIFF
--- a/completion_aggregator/apps.py
+++ b/completion_aggregator/apps.py
@@ -14,3 +14,9 @@ class CompletionAggregatorConfig(AppConfig):
     """
 
     name = 'completion_aggregator'
+
+    def ready(self):
+        """
+        Load signal handlers when the app is ready.
+        """
+        from . import signals as _

--- a/completion_aggregator/signals.py
+++ b/completion_aggregator/signals.py
@@ -1,0 +1,43 @@
+"""
+Handlers for signals emitted by block completion models.
+"""
+
+import logging
+
+from django.conf import settings
+from django.db.models.signals import post_save
+
+log = logging.getLogger(__name__)
+
+
+def _get_aggregated_model():
+    """
+    Return a string naming the model that we are aggregating.
+
+    Normally, this will be 'completion.BlockCompletion', but tests will need to
+    override it to avoid hooking into edx-platform.
+    """
+    return getattr(settings, 'COMPLETION_AGGREGATED_MODEL_OVERRIDE', 'completion.BlockCompletion')
+
+
+def completion_update_handler(signal, sender, instance, created, raw, using, update_fields, **kwargs):  # pylint: disable=unused-argument
+    """
+    Update aggregate completions based on a changed block.
+    """
+    if raw:  # pragma: no cover
+        # Raw saves are performed when loading fixtures, and should not cause
+        # cascading updates.  This is excluded from coverage, because the only
+        # method django provides for loading fixtures is via a management
+        # command.
+        return
+
+    # The implementation for this will be handled in OC-3098.
+    log.info(
+        "Updating aggregators for %s/%s.  Updated block: %s",
+        instance.user.username,
+        instance.course_key,
+        instance.block_key,
+    )
+
+
+post_save.connect(completion_update_handler, sender=_get_aggregated_model())

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,5 +2,6 @@
 
 ddt			  # Provides test parameterization
 django-model-utils        # Provides TimeStampedModel abstract base class
+mock
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,7 +9,8 @@ coverage==4.5.1           # via pytest-cov
 ddt==1.1.1
 django-model-utils==3.1.1
 edx-opaque-keys==0.4.2
-pbr==3.1.1                # via stevedore
+mock==2.0.0
+pbr==3.1.1                # via mock, stevedore
 pluggy==0.6.0             # via pytest
 py==1.5.2                 # via pytest
 pymongo==3.6.0            # via edx-opaque-keys

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ skip_glob = **/migrations/*.py
 
 [wheel]
 universal = 1
+
+[pycodestyle]
+ignore = E501

--- a/test_settings.py
+++ b/test_settings.py
@@ -42,3 +42,5 @@ LOCALE_PATHS = [
 ROOT_URLCONF = 'completion_aggregator.urls'
 
 SECRET_KEY = 'insecure-secret-key'
+
+COMPLETION_AGGREGATED_MODEL_OVERRIDE = 'test_app.Completable'

--- a/test_utils/test_app/apps.py
+++ b/test_utils/test_app/apps.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+Test App Django application initialization.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+from django.apps import AppConfig
+
+
+class TestAppConfig(AppConfig):
+    """
+    Configuration for the test_app.
+    """
+
+    name = 'test_app'

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,35 @@
+"""
+Tests that exercise completion signals and handlers.
+
+Demonstrate that the signals connect the handler to the aggregated model.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from mock import patch
+from opaque_keys.edx.keys import CourseKey, UsageKey
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from test_utils.test_app.models import Completable
+
+
+class SignalCalledTestCase(TestCase):
+    """
+    Test that the the signal handler receives the signal when the aggregated model
+    is saved
+    """
+    def setUp(self):
+        self.user = User.objects.create()
+
+    @patch('completion_aggregator.signals.log.info')
+    def test_basic(self, mock_log):
+        completable = Completable(
+            user=self.user,
+            course_key=CourseKey.from_string('edX/test/2018'),
+            block_key=UsageKey.from_string('i4x://edX/test/video/friday'),
+            completion=1.0,
+        )
+        completable.save()
+        mock_log.assert_called_once()


### PR DESCRIPTION
**Description:** This connects the completion_aggregator app to the signal fired when a BlockCompletion gets saved.  A follow-up PR (#4) will implement responding to that signal to update Aggregators for the course.  For now, it just logs that the update happened.

**JIRA:** MCKIN-5902, OC-3097

**Dependencies:** Depends on aggregator model PR, #1, currently waiting on upstream review.

**Merge deadline:** None

**Testing instructions:** 

1. Run the test suite, and see that tests pass.
2. Configure logging to display DEBUG level logs.
3. Install into a current version of edx-platform. (pip install the repo, at this branch and update the INSTALLED_APPS in lms/envs/common.py)
4. Enable the completion waffle switch. (completion.enable_completion_tracking)
5. Work through a course to create new completion objects, or manually create BlockCompletions from the shell.
6. See that the logs were updated with entries from the completion_aggregator namespace.

**Reviewers:**
- [ ] @macornwell
- [ ] @iloveagent57

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** Code isn't really a complete feature as-is.  Not useful until the follow-up PR lands.
