### PR TITLE
Convert completion-aggregator to pluggable django app.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,24 +10,25 @@ completion data for different block types for Open edX.
 Overview
 --------
 
+openedx-completion-aggregator uses the pluggable django app pattern to
+ease installation.  To use in edx-platform, simply install the app into
+your virtualenv.
+
 ..code_block::
 
     $ pip install openedx-completion-aggregator
 
-Add to settings.py::
+You may override the set of registered aggregator block types in your
+lms.env.json file::
 
-    INSTALLED_APPS += 'completion_aggregator'
-    COMPLETION_AGGREGATED_BLOCKS = [
-        'chapter',
-        'subsection',
-        'vertical',
-    ]
+    ...
+    "COMPLETION_AGGREGATOR_BLOCK_TYPES": {
+        "chapter",
+        "subsection",
+        "vertical"
+    },
+    ...
 
-Add to urls.py::
-
-    urlpatterns += [
-       url('^completion/', include('completion_aggregator.urls'))
-    ]
 
 Documentation
 -------------

--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -6,4 +6,4 @@ from __future__ import absolute_import, unicode_literals
 
 __version__ = '0.1.0'
 
-default_app_config = 'completion_aggregator.apps.CompletionAggregatorConfig'  # pylint: disable=invalid-name
+default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/apps.py
+++ b/completion_aggregator/apps.py
@@ -8,12 +8,27 @@ from __future__ import absolute_import, unicode_literals
 from django.apps import AppConfig
 
 
-class CompletionAggregatorConfig(AppConfig):
+class CompletionAggregatorAppConfig(AppConfig):
     """
     Configuration for the completion_aggregator Django application.
     """
 
     name = 'completion_aggregator'
+    plugin_app = {
+        'url_config': {
+            'lms.djangoapp': {
+                'namespace': 'completion_aggregator',
+                'regex': r'^completion-aggregator/',
+                'relative_path': 'completion_aggregator.urls',
+            },
+        },
+        'settings_config': {
+            'lms.djangoapp': {
+                'aws': {'relative_path': 'settings.aws'},
+                'common': {'relative_path': 'settings.common'},
+            },
+        },
+    }
 
     def ready(self):
         """

--- a/completion_aggregator/settings/aws.py
+++ b/completion_aggregator/settings/aws.py
@@ -1,0 +1,15 @@
+"""
+AWS settings for completion_aggregator.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+
+def plugin_settings(settings):
+    """
+    Modify the provided settings object with settings specific to this plugin.
+    """
+    settings.COMPLETION_AGGREGATOR_BLOCK_TYPES = settings.ENV_TOKENS.get(
+        'COMPLETION_AGGREGATOR_BLOCK_TYPES',
+        settings.COMPLETION_AGGREGATOR_BLOCK_TYPES
+    )

--- a/completion_aggregator/settings/common.py
+++ b/completion_aggregator/settings/common.py
@@ -1,0 +1,16 @@
+"""
+Common settings for completion_aggregator.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+
+def plugin_settings(settings):
+    """
+    Modify the provided settings object with settings specific to this plugin.
+    """
+    settings.COMPLETION_AGGREGATOR_BLOCK_TYPES = {
+        'chapter',
+        'sequential',
+        'vertical',
+    }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,7 +46,7 @@ pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.6.0            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
-pytz==2018.3              # via django
+pytz==2018.3              # via celery, django
 pyyaml==3.12              # via edx-i18n-tools
 requests-toolbelt==0.8.0  # via twine
 requests==2.18.4          # via caniusepython3, requests-toolbelt, twine

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,14 +10,14 @@ bleach==2.1.2             # via readme-renderer
 certifi==2018.1.18        # via requests
 chardet==3.0.4            # via doc8, requests
 django-model-utils==3.1.1
-django==2.0.2
+django==1.11.10
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-opaque-keys==0.4.2
 edx-sphinx-theme==1.3.0
 html5lib==1.0.1           # via bleach
 idna==2.6                 # via requests
-imagesize==0.7.1          # via sphinx
+imagesize==1.0.0          # via sphinx
 jinja2==2.10              # via sphinx
 markupsafe==1.0           # via jinja2
 packaging==16.8           # via sphinx
@@ -25,7 +25,7 @@ pbr==3.1.1                # via stevedore
 pygments==2.2.0           # via readme-renderer, sphinx
 pymongo==3.6.0            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
-pytz==2018.3              # via babel, django
+pytz==2018.3              # via babel, celery, django
 readme-renderer==17.2
 requests==2.18.4          # via sphinx
 restructuredtext-lint==1.1.2  # via doc8

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,7 +15,7 @@ pluggy==0.6.0             # via pytest
 py==1.5.2                 # via pytest
 pymongo==3.6.0            # via edx-opaque-keys
 pytest-cov==2.5.1
-pytest==3.4.0             # via pytest-cov, pytest-django
-pytz==2018.3              # via django
-six==1.11.0               # via edx-opaque-keys, pytest, stevedore
+pytest==3.4.1             # via pytest-cov, pytest-django
+pytz==2018.3              # via celery, django
+six==1.11.0               # via edx-opaque-keys, mock, pytest, stevedore
 stevedore==1.28.0         # via edx-opaque-keys

--- a/setup.py
+++ b/setup.py
@@ -72,4 +72,10 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
+    entry_points={
+        'lms.djangoapp': [
+            'completion_aggregator = completion_aggregator.apps:CompletionAggregatorAppConfig'
+        ],
+        'cms.djangoapp': [],
+    }
 )


### PR DESCRIPTION
**Description:** edx-platform has recently added a pattern for including code as a "plugin" (without needing to add configuration to edx-platform).  This makes completion-aggregator follow that pattern.

**JIRA:** OC-3969

**Dependencies:** Waiting on #1 to land.

**Merge deadline:** None

**Installation instructions:** Make sure there is no existing version of openedx-completion-aggregator installed (via `pip freeze`), then pip install this branch into a devstack running a recent commit on the master branch of edx-platform.

**Testing instructions:**

After installing per the instructions above:

1. Run `./manage.py lms --settings=devstack_docker shell`
2. Verify that `completion_aggregator.apps.CompletionAggregatorAppConfig` was added to `django.conf.settings.INSTALLED_APPS`.
3. Verify that `django.conf.settings.COMPLETION_AGGREGATOR_BLOCK_TYPES` exists and is set to   `set([u'chapter', u'sequential', u'vertical'])`.

**Reviewers:**
- [x] @macornwell

FYI @pomegranited -- Since you suggested we use this pattern for this app.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 