### PR TITLE
Calculate completion only for relevant sub-graphs of a course

### DIFF
--- a/completion_aggregator/compat.py
+++ b/completion_aggregator/compat.py
@@ -8,7 +8,7 @@ This needs to be stubbed out for tests.  If a module, `caller` calls:
 It can be stubbed out using:
 
     import test_utils.compat
-    mock.patch('caller.compat', test_utils.compat.StubCompat())
+    mock.patch('caller.compat', test_utils.compat.StubCompat(list_of_usage_keys))
 
 `StubCompat` is a class which implements all the below methods in a way that
 eliminates external dependencies
@@ -16,6 +16,8 @@ eliminates external dependencies
 from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
+
+from .transformers import AggregatorAnnotationTransformer
 
 
 def get_aggregated_model():
@@ -36,6 +38,14 @@ def init_course_block_key(modulestore, course_key):
     return modulestore.make_course_usage_key(course_key)
 
 
+def get_modulestore():
+    """
+    Return an instance of the modulestore.
+    """
+    from xmodule.modulestore.django import modulestore   # pylint: disable=import-error
+    return modulestore()
+
+
 def init_course_blocks(user, course_block_key):
     """
     Return a BlockStructure representing the course.
@@ -46,8 +56,14 @@ def init_course_blocks(user, course_block_key):
         .block_type
     """
     # pragma: no-cover
-    from lms.djangoapps.course_blocks.api import get_course_blocks  # pylint: disable=import-error
-    return get_course_blocks(user, course_block_key)
+    from lms.djangoapps.course_blocks.api import get_course_block_access_transformers, get_course_blocks  # pylint: disable=import-error
+    from openedx.core.djangoapps.content.block_structure.transformers import BlockStructureTransformers  # pylint: disable=import-error
+
+    transformers = BlockStructureTransformers(
+        get_course_block_access_transformers() + [AggregatorAnnotationTransformer()]
+    )
+
+    return get_course_blocks(user, course_block_key, transformers)
 
 
 def get_block_completions(user, course_key):
@@ -84,3 +100,18 @@ def course_enrollment_model():
     # pragma: no-cover
     from student.models import CourseEnrollment  # pylint: disable=import-error
     return CourseEnrollment
+
+
+def get_affected_aggregators(course_blocks, changed_blocks):
+    """
+    Return the set of aggregator blocks that may need updating.
+    """
+    affected_aggregators = set()
+    for block in changed_blocks:
+        block_aggregators = course_blocks.get_transformer_block_field(
+            block,
+            AggregatorAnnotationTransformer,
+            AggregatorAnnotationTransformer.AGGREGATORS
+        )
+        affected_aggregators.update(block_aggregators)
+    return affected_aggregators

--- a/completion_aggregator/settings/common.py
+++ b/completion_aggregator/settings/common.py
@@ -10,6 +10,7 @@ def plugin_settings(settings):
     Modify the provided settings object with settings specific to this plugin.
     """
     settings.COMPLETION_AGGREGATOR_BLOCK_TYPES = {
+        'course',
         'chapter',
         'sequential',
         'vertical',

--- a/completion_aggregator/transformers.py
+++ b/completion_aggregator/transformers.py
@@ -1,0 +1,78 @@
+"""
+Transformers for completion aggregation.
+"""
+
+try:
+    from openedx.core.djangoapps.content.block_structure.transformer import BlockStructureTransformer
+except ImportError:
+    BlockStructureTransformer = object
+
+from xblock.completable import XBlockCompletionMode
+
+
+class AggregatorAnnotationTransformer(BlockStructureTransformer):
+    """
+    Annotate completable blocks with the aggregators which contain them.
+    """
+
+    READ_VERSION = 1
+    WRITE_VERSION = 1
+    AGGREGATORS = "aggregators"
+
+    @classmethod
+    def name(cls):
+        """
+        Return the name of the transformer.
+        """
+        return "completion_aggregator_annotator"
+
+    @classmethod
+    def get_block_aggregators(cls, block_structure, block_key):
+        """
+        Return the aggregators which contain this block.
+
+        Arguments:
+            block_structure: a BlockStructure instance
+            block_key: the key of the block whose aggregators we want
+        Returns:
+            aggregators: list or None
+
+        """
+        return block_structure.get_transformer_block_field(block_key, cls, cls.AGGREGATORS)
+
+    @classmethod
+    def collect(cls, block_structure):
+        """
+        Collect the data required to perform this calculation.
+        """
+        block_structure.request_xblock_fields("completion_mode")
+
+    def calculate_aggregators(self, block_structure, block_key):
+        """
+        Calculate the set of aggregators for the specified block.
+        """
+        aggregators = set()
+        parents = block_structure.get_parents(block_key)
+        for parent in parents:
+            parent_block = block_structure[parent]
+            completion_mode = getattr(parent_block, 'completion_mode', XBlockCompletionMode.COMPLETABLE)
+            if completion_mode == XBlockCompletionMode.EXCLUDED:
+                continue
+            elif completion_mode == XBlockCompletionMode.AGGREGATOR:
+                aggregators.add(parent)
+            aggregators.update(self.get_block_aggregators(block_structure, parent))
+        return aggregators
+
+    def transform(self, usage_info, block_structure):  # pylint: disable=unused-argument
+        """
+        Add a field holding a list of the block's aggregators.
+        """
+        for block_key in block_structure.topological_traversal():
+            completion_mode = block_structure.get_xblock_field(
+                block_key,
+                "completion_mode",
+                XBlockCompletionMode.COMPLETABLE
+            )
+            if completion_mode != XBlockCompletionMode.EXCLUDED:
+                aggregators = self.calculate_aggregators(block_structure, block_key)
+                block_structure.set_transformer_block_field(block_key, self, self.AGGREGATORS, aggregators)

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,11 @@ setup(
         'lms.djangoapp': [
             'completion_aggregator = completion_aggregator.apps:CompletionAggregatorAppConfig'
         ],
-        'cms.djangoapp': [ 
+        'cms.djangoapp': [
             'completion_aggregator = completion_aggregator.apps:CompletionAggregatorAppConfig'
+        ],
+        'openedx.block_structure_transformer': [
+            'completion_aggregator_annotator = completion_aggregator.transformers:AggregatorAnnotationTransformer',
         ],
     }
 )

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -4,9 +4,9 @@ Test compatibility layer that reduces dependence on edx-platform.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import itertools
+import collections
 
-import six
+from mock import MagicMock
 
 from completion.models import BlockCompletion
 
@@ -19,6 +19,9 @@ class StubCompat(object):
     replaced with local elements.
     """
 
+    def __init__(self, blocks):
+        self.blocks = blocks
+
     def init_course_block_key(self, modulestore, course_key):  # pylint: disable=unused-argument
         """
         Create a root usage key for the course.
@@ -27,14 +30,24 @@ class StubCompat(object):
         """
         return course_key.make_usage_key('course', 'course')
 
-    def init_course_blocks(self, user, course_block_key):
+    def init_course_blocks(self, user, course_block_key):  # pylint: disable=unused-argument
         """
         Not actually used in this implmentation.
 
         Overridden here to prevent the default behavior, which relies on
         modulestore.
         """
-        pass
+        return CompatCourseBlocks(*self.blocks)
+
+    def get_affected_aggregators(self, course_blocks, changed_blocks):
+        """
+        Get all the aggregator blocks affected by a change to one of the given blocks.
+        """
+        affected = set()
+        for block in course_blocks.blocks:
+            if any(changed.block_id.startswith('{}-'.format(block.block_id)) for changed in changed_blocks):
+                affected.add(block)
+        return affected
 
     def get_block_completions(self, user, course_key):
         """
@@ -42,41 +55,47 @@ class StubCompat(object):
         """
         return BlockCompletion.objects.filter(user=user, course_key=course_key)
 
-    def get_children(self, course_blocks, block_key):  # pylint: disable=unused-argument
+    def get_children(self, course_blocks, block_key):
         """
         Return children for the given block.
-
-        For the purpose of the tests, we will use the following course
-        structure:
-
-                        course
-                          |
-                +--+---+--^-+----+----+
-               /   |   |    |    |     \
-            html html html html other hidden
-                                /   \
-                              html hidden
-
-        where `course` and `other` are a completion_mode of AGGREGATOR (but
-        only `course` is registered to store aggregations), `html` is
-        COMPLETABLE, and `hidden` is EXCLUDED.
         """
-        course_key = block_key.course_key
-        if block_key.block_type == 'course':
-            return list(itertools.chain(
-                [course_key.make_usage_key('html', 'html{}'.format(i)) for i in six.moves.range(4)],
-                [course_key.make_usage_key('other', 'other')],
-                [course_key.make_usage_key('hidden', 'hidden0')]
-            ))
-        elif block_key.block_type == 'other':
-            return [
-                course_key.make_usage_key('html', 'html4'),
-                course_key.make_usage_key('hidden', 'hidden1')
-            ]
-        return []
+        return [
+            block for block in course_blocks.blocks if course_blocks.is_child(block, block_key)
+        ]
+
+    def get_modulestore(self):
+        """
+        This implementation doesn't need a modulestore.
+
+        The user will still call methods on it, so we provide a MagicMock.
+        """
+        return MagicMock()
 
     def course_enrollment_model(self):
         """
         Return this replacement for CourseEnrollment
         """
         return CourseEnrollment
+
+
+CourseTreeNode = collections.namedtuple('CourseTreeNode', ['block', 'children'])
+
+
+class CompatCourseBlocks(object):
+    """
+    Given a list of blocks, creates a course tree for testing.
+
+    In this course tree, blocks are implicitly nested by their block id, with
+    segments separated by hyphens.
+    """
+
+    def __init__(self, *blocks):
+        self.blocks = blocks
+
+    def is_child(self, child, parent):
+        parent_segments = parent.block_id.split('-')
+        child_segments = child.block_id.split('-')
+        return (
+            len(child_segments) == len(parent_segments) + 1
+            and child_segments[:-1] == parent_segments
+        )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from datetime import timedelta
 
 import mock
+import pytest
+import six
 from opaque_keys.edx.keys import CourseKey
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
@@ -17,7 +19,7 @@ from django.utils.timezone import now
 
 from completion.models import BlockCompletion
 from completion_aggregator.models import Aggregator
-from completion_aggregator.tasks import AggregationUpdater
+from completion_aggregator.tasks import OLD_DATETIME, AggregationUpdater, update_aggregators
 from test_utils.compat import StubCompat
 
 
@@ -49,6 +51,13 @@ class OtherAggBlock(XBlock):
     completion_mode = XBlockCompletionMode.AGGREGATOR
 
 
+class InvalidModeBlock(XBlock):
+    """
+    A block with an invalid value for completion mode.
+    """
+    completion_mode = 'not-a-completion-mode'
+
+
 class AggregationUpdaterTestCase(TestCase):
     """
     Test the AggregationUpdater.
@@ -56,11 +65,38 @@ class AggregationUpdaterTestCase(TestCase):
     It should create Aggregator records for new completion objects.
     """
     def setUp(self):
+        """
+        For the purpose of the tests, we will use the following course
+        structure:
+
+                        course
+                          |
+                +--+---+--^-+----+----+
+               /   |   |    |    |     \\
+            html html html html other hidden
+                                /   \\
+                              html hidden
+
+        where `course` and `other` are a completion_mode of AGGREGATOR (but
+        only `course` is registered to store aggregations), `html` is
+        COMPLETABLE, and `hidden` is EXCLUDED.
+        """
         self.agg_modified = now() - timedelta(days=1)
-        patch = mock.patch('completion_aggregator.tasks.compat', StubCompat())
+        course_key = CourseKey.from_string('course-v1:edx+course+test')
+        patch = mock.patch('completion_aggregator.tasks.compat', StubCompat([
+            course_key.make_usage_key('course', 'course'),
+            course_key.make_usage_key('html', 'course-html0'),
+            course_key.make_usage_key('html', 'course-html1'),
+            course_key.make_usage_key('html', 'course-html2'),
+            course_key.make_usage_key('html', 'course-html3'),
+            course_key.make_usage_key('other', 'course-other'),
+            course_key.make_usage_key('hidden', 'course-hidden0'),
+            course_key.make_usage_key('html', 'course-other-html4'),
+            course_key.make_usage_key('hidden', 'course-other-hidden1'),
+        ]))
         patch.start()
         self.addCleanup(patch.stop)
-        user = get_user_model().objects.create()
+        user = get_user_model().objects.create(username='saskia')
         self.course_key = CourseKey.from_string('course-v1:edx+course+test')
         self.agg, _ = Aggregator.objects.submit_completion(
             user=user,
@@ -74,7 +110,7 @@ class AggregationUpdaterTestCase(TestCase):
         BlockCompletion.objects.create(
             user=user,
             course_key=self.course_key,
-            block_key=self.course_key.make_usage_key('html', 'html4'),
+            block_key=self.course_key.make_usage_key('html', 'course-other-html4'),
             completion=1.0,
             modified=now(),
         )
@@ -86,6 +122,17 @@ class AggregationUpdaterTestCase(TestCase):
     @XBlock.register_temp_plugin(OtherAggBlock, 'other')
     def test_aggregation_update(self):
         self.updater.update()
+        self.agg.refresh_from_db()
+        assert self.agg.last_modified > self.agg_modified
+        assert self.agg.earned == 1.0
+        assert self.agg.possible == 5.0
+
+    @XBlock.register_temp_plugin(CourseBlock, 'course')
+    @XBlock.register_temp_plugin(HTMLBlock, 'html')
+    @XBlock.register_temp_plugin(HiddenBlock, 'hidden')
+    @XBlock.register_temp_plugin(OtherAggBlock, 'other')
+    def test_end_to_end_task_calling(self):
+        update_aggregators(username='saskia', course_key='course-v1:edx+course+test')
         self.agg.refresh_from_db()
         assert self.agg.last_modified > self.agg_modified
         assert self.agg.earned == 1.0
@@ -113,3 +160,145 @@ class AggregationUpdaterTestCase(TestCase):
         assert agg.aggregation_name == 'course'
         assert agg.earned == 1.0
         assert agg.possible == 5.0
+
+    @XBlock.register_temp_plugin(CourseBlock, 'course')
+    @XBlock.register_temp_plugin(InvalidModeBlock, 'html')
+    @XBlock.register_temp_plugin(HiddenBlock, 'hidden')
+    @XBlock.register_temp_plugin(OtherAggBlock, 'other')
+    def test_invalid_completion_mode(self):
+        with pytest.raises(ValueError):
+            self.updater.update()
+
+
+class PartialUpdateTest(TestCase):
+    """
+    Test that when performing an update for a particular block or subset of
+    blocks, that only part of the course tree gets aggregated.
+    """
+    def setUp(self):
+        self.user = get_user_model().objects.create()
+        self.course_key = CourseKey.from_string('OpenCraft/Onboarding/2018')
+        self.blocks = [
+            self.course_key.make_usage_key('course', 'course'),
+            self.course_key.make_usage_key('chapter', 'course-chapter1'),
+            self.course_key.make_usage_key('chapter', 'course-chapter2'),
+            self.course_key.make_usage_key('html', 'course-chapter1-block1'),
+            self.course_key.make_usage_key('html', 'course-chapter1-block2'),
+            self.course_key.make_usage_key('html', 'course-chapter2-block1'),
+            self.course_key.make_usage_key('html', 'course-chapter2-block2'),
+        ]
+        patch = mock.patch('completion_aggregator.tasks.compat', StubCompat(self.blocks))
+        patch.start()
+        self.addCleanup(patch.stop)
+
+    @XBlock.register_temp_plugin(CourseBlock, 'course')
+    @XBlock.register_temp_plugin(OtherAggBlock, 'chapter')
+    @XBlock.register_temp_plugin(HTMLBlock, 'html')
+    def test_partial_updates(self):
+        instant = now()
+        completion = BlockCompletion.objects.create(
+            user=self.user,
+            course_key=self.course_key,
+            block_key=self.blocks[4],
+            completion=0.75,
+            modified=instant,
+        )
+
+        updater = AggregationUpdater(self.user, self.course_key, mock.MagicMock())
+        updater.update(changed_blocks={self.blocks[4]})
+        course_agg = Aggregator.objects.get(course_key=self.course_key, block_key=self.blocks[0])
+        chap1_agg = Aggregator.objects.get(course_key=self.course_key, block_key=self.blocks[1])
+        chap2_agg = Aggregator.objects.get(course_key=self.course_key, block_key=self.blocks[2])
+        self.assertEqual(chap1_agg.earned, 0.75)
+        self.assertEqual(chap1_agg.last_modified, completion.modified)
+        self.assertEqual(chap2_agg.earned, 0.0)
+        self.assertEqual(chap2_agg.last_modified, OLD_DATETIME)
+        self.assertEqual(course_agg.earned, 0.75)
+        self.assertEqual(course_agg.last_modified, completion.modified)
+
+    @XBlock.register_temp_plugin(CourseBlock, 'course')
+    @XBlock.register_temp_plugin(OtherAggBlock, 'chapter')
+    @XBlock.register_temp_plugin(HTMLBlock, 'html')
+    def test_multiple_partial_updates(self):
+        completion = BlockCompletion.objects.create(
+            user=self.user,
+            course_key=self.course_key,
+            block_key=self.blocks[4],
+            completion=0.75,
+        )
+        update_aggregators(self.user.username, six.text_type(self.course_key), {six.text_type(completion.block_key)})
+
+        new_completions = [
+            BlockCompletion.objects.create(
+                user=self.user,
+                course_key=self.course_key,
+                block_key=self.blocks[5],
+                completion=1.0,
+            ),
+            BlockCompletion.objects.create(
+                user=self.user,
+                course_key=self.course_key,
+                block_key=self.blocks[6],
+                completion=0.5,
+            ),
+        ]
+        update_aggregators(
+            username=self.user.username,
+            course_key=six.text_type(self.course_key),
+            block_keys=[six.text_type(comp.block_key) for comp in new_completions]
+        )
+
+        course_agg = Aggregator.objects.get(course_key=self.course_key, block_key=self.blocks[0])
+        chap1_agg = Aggregator.objects.get(course_key=self.course_key, block_key=self.blocks[1])
+        chap2_agg = Aggregator.objects.get(course_key=self.course_key, block_key=self.blocks[2])
+        self.assertEqual(chap1_agg.earned, 0.75)
+        self.assertEqual(chap1_agg.last_modified, completion.modified)
+        self.assertEqual(chap2_agg.earned, 1.5)
+        self.assertEqual(chap2_agg.last_modified, new_completions[1].modified)
+        self.assertEqual(course_agg.earned, 2.25)
+        self.assertEqual(course_agg.last_modified, new_completions[1].modified)
+
+
+class TaskArgumentHandling(TestCase):
+    """
+    Celery tasks must be called with primitive python types.
+
+    Verify that they are properly parsed before calling into the function that
+    does the real work.
+    """
+
+    def setUp(self):
+        self.user = get_user_model().objects.create(username='sandystudent')
+        self.course_key = CourseKey.from_string('course-v1:OpenCraft+Onboarding+2018')
+        self.block_keys = {
+            self.course_key.make_usage_key('html', 'course-chapter-html0'),
+            self.course_key.make_usage_key('html', 'course-chapter-html1'),
+        }
+
+    @mock.patch('completion_aggregator.tasks._update_aggregators')
+    def test_calling_task_with_no_blocks(self, mock_update):
+        update_aggregators(username='sandystudent', course_key='course-v1:OpenCraft+Onboarding+2018')
+        mock_update.assert_called_once_with(
+            self.user, self.course_key, frozenset(), False
+        )
+
+    @mock.patch('completion_aggregator.tasks._update_aggregators')
+    def test_calling_task_with_changed_blocks(self, mock_update):
+        update_aggregators(
+            username='sandystudent',
+            course_key='course-v1:OpenCraft+Onboarding+2018',
+            block_keys=[
+                'block-v1:OpenCraft+Onboarding+2018+type@html+block@course-chapter-html0',
+                'block-v1:OpenCraft+Onboarding+2018+type@html+block@course-chapter-html1',
+            ],
+        )
+        mock_update.assert_called_once_with(
+            self.user,
+            self.course_key,
+            self.block_keys,
+            False,
+        )
+
+    def test_unknown_username(self):
+        with pytest.raises(get_user_model().DoesNotExist):
+            update_aggregators(username='sanfordstudent', course_key='course-v1:OpenCraft+Onboarding+2018')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -50,7 +50,7 @@ def _create_oauth2_token(user):
     return dot_access_token.token
 
 
-@patch('completion_aggregator.api.v1.views.compat', StubCompat())
+@patch('completion_aggregator.api.v1.views.compat', StubCompat([]))
 class CompletionViewTestCase(TestCase):
     """
     Test that the CompletionView renders completion data properly.
@@ -60,7 +60,7 @@ class CompletionViewTestCase(TestCase):
     other_org_course_key = CourseKey.from_string('otherOrg/toy/2012_Fall')
     list_url = '/v1/course/'
     detail_url_fmt = '/v1/course/{}/'
-    course_enrollment_model = StubCompat().course_enrollment_model()
+    course_enrollment_model = StubCompat([]).course_enrollment_model()
 
     def setUp(self):
         self.test_user = User.objects.create(username='test_user')


### PR DESCRIPTION
**Description:**

This limits completion aggregation to relevant subgraphs of a course, by adding a block structure transformer that annotates completable blocks with the aggregator blocks that contain them.

**JIRA:** OC-3967

**Testing instructions:**

I created a two-section course, each section containing one unit with an HTML component and an input problem. This makes it reasonably easy to monitor the completion aggregation.

These changes should result in no noticeable alteration to the end result of completion aggregation, but in the logs, you should see that only the aggregator blocks containing the blocks you complete are updated.

**Reviewers:**
- [ ] @pomegranited This is ready for review.


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 

This has lots of debugging logging that should be removed.