### PR TITLE
[MCKIN-7324] Provide API endpoint to fetch aggregators for all enrolled users in a course

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 J. Cliff Dyer <cliff@opencraft.com>
 Michael Cornwell <michael@opencraft.com>
+Jillian Vogel <jill@opencraft.com>

--- a/completion_aggregator/api/v1/views.py
+++ b/completion_aggregator/api/v1/views.py
@@ -68,7 +68,7 @@ class CompletionViewMixin(object):
     Common functionality for completion views.
     """
 
-    _allowed_requested_fields = {'mean', 'user'}
+    _allowed_requested_fields = {'mean', 'username'}
     permission_classes = (IsAuthenticated,)
     _effective_user = None
     _requested_user = None
@@ -489,7 +489,7 @@ class CompletionDetailView(CompletionViewMixin, APIView):
         if not self.requested_user and self.user.is_staff:
             # Use all enrollments for the course
             enrollments = UserEnrollments().get_course_enrollments(course_key)
-            requested_fields.add('user')
+            requested_fields.add('username')
         else:
             if not UserEnrollments(self.user).is_enrolled(course_key):
                 # Return 404 if effective user does not have an active enrollment in the requested course

--- a/completion_aggregator/api/v1/views.py
+++ b/completion_aggregator/api/v1/views.py
@@ -82,7 +82,7 @@ class CompletionViewMixin(object):
         """
         Return the class to use for pagination
         """
-        from openedx.core.lib.api import paginators  # pylint: disable=import-error
+        from edx_rest_framework_extensions import paginators  # pylint: disable=import-error
         return paginators.NamespacedPageNumberPagination
 
     @property

--- a/completion_aggregator/api/v1/views.py
+++ b/completion_aggregator/api/v1/views.py
@@ -173,18 +173,18 @@ class CompletionListView(CompletionViewMixin, APIView):
         The response is a dictionary comprising pagination data and a page
         of results.
 
-        * pagination: A dict of pagination information, containing the fields:
-            * page: The page number of the current set of results.
-            * next: The URL for the next page of results, or None if already on
-              the last page.
-            * previous: The URL for the previous page of results, or None if
-              already on the first page.
-            * count: The total number of available results.
+        * page: The page number of the current set of results.
+        * next: The URL for the next page of results, or None if already on
+          the last page.
+        * previous: The URL for the previous page of results, or None if
+          already on the first page.
+        * count: The total number of available results.
         * results: A list of dictionaries representing the user's completion
           for each course.
 
         Standard fields for each completion dictionary:
 
+        * course_key (CourseKey): The unique course identifier.
         * completion: A dictionary comprising of the following fields:
             * earned (float): The sum of the learner's completions.
             * possible (float): The total number of completions available
@@ -234,12 +234,12 @@ class CompletionListView(CompletionViewMixin, APIView):
             GET /api/completion/v1/course
 
             {
-              "pagination": {
-                "count": 14,
-                "page": 1,
-                "next": "/api/completion/v1/course/?page=2,
-                "previous": None
-              },
+              "count": 14,
+              "num_pages": 1,
+              "current_page": 1,
+              "start": 1,
+              "next": "/api/completion/v1/course/?page=2,
+              "previous": None,
               "results": [
                 {
                   "course_key": "edX/DemoX/Demo_course",

--- a/completion_aggregator/compat.py
+++ b/completion_aggregator/compat.py
@@ -13,6 +13,7 @@ It can be stubbed out using:
 `StubCompat` is a class which implements all the below methods in a way that
 eliminates external dependencies
 """
+from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 
@@ -74,3 +75,12 @@ def get_children(course_blocks, block_key):
     without access to edx-platform, so tests will want to stub it out.
     """
     return course_blocks.get_children(block_key)
+
+
+def course_enrollment_model():
+    """
+    Return the student.models.CourseEnrollment model.
+    """
+    # pragma: no-cover
+    from student.models import CourseEnrollment  # pylint: disable=import-error
+    return CourseEnrollment

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -180,6 +180,18 @@ class _CompletionSerializer(serializers.Serializer):
     percent = serializers.FloatField()
 
 
+class UserPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):
+    """
+    Serialize just the username.
+    """
+
+    def to_representation(self, value):
+        """
+        Serialize the username (instead of pk).
+        """
+        return value.username
+
+
 class CourseCompletionSerializer(serializers.Serializer):
     """
     Serialize completions at the course level.
@@ -187,9 +199,10 @@ class CourseCompletionSerializer(serializers.Serializer):
 
     course_key = serializers.CharField()
     completion = _CompletionSerializer(source='*')
+    user = UserPrimaryKeyRelatedField(read_only=True)
     mean = serializers.FloatField()
 
-    optional_fields = {'mean'}
+    optional_fields = {'mean', 'user'}
 
     def __init__(self, instance, requested_fields=frozenset(), *args, **kwargs):
         """

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -180,18 +180,6 @@ class _CompletionSerializer(serializers.Serializer):
     percent = serializers.FloatField()
 
 
-class UserPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):
-    """
-    Serialize just the username.
-    """
-
-    def to_representation(self, value):
-        """
-        Serialize the username (instead of pk).
-        """
-        return value.username
-
-
 class CourseCompletionSerializer(serializers.Serializer):
     """
     Serialize completions at the course level.
@@ -199,10 +187,10 @@ class CourseCompletionSerializer(serializers.Serializer):
 
     course_key = serializers.CharField()
     completion = _CompletionSerializer(source='*')
-    user = UserPrimaryKeyRelatedField(read_only=True)
+    username = serializers.SerializerMethodField()
     mean = serializers.FloatField()
 
-    optional_fields = {'mean', 'user'}
+    optional_fields = {'mean', 'username'}
 
     def __init__(self, instance, requested_fields=frozenset(), *args, **kwargs):
         """
@@ -213,6 +201,12 @@ class CourseCompletionSerializer(serializers.Serializer):
         super(CourseCompletionSerializer, self).__init__(instance, *args, **kwargs)
         for field in self.optional_fields - requested_fields:
             del self.fields[field]
+
+    def get_username(self, obj):
+        """
+        Serialize the username.
+        """
+        return obj.user.username
 
 
 class BlockCompletionSerializer(serializers.Serializer):

--- a/completion_aggregator/signals.py
+++ b/completion_aggregator/signals.py
@@ -1,6 +1,7 @@
 """
 Handlers for signals emitted by block completion models.
 """
+from __future__ import absolute_import, unicode_literals
 
 import logging
 

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -10,6 +10,8 @@ import six
 
 from completion.models import BlockCompletion
 
+from .test_app.models import CourseEnrollment
+
 
 class StubCompat(object):
     """
@@ -72,3 +74,9 @@ class StubCompat(object):
                 course_key.make_usage_key('hidden', 'hidden1')
             ]
         return []
+
+    def course_enrollment_model(self):
+        """
+        Return this replacement for CourseEnrollment
+        """
+        return CourseEnrollment

--- a/test_utils/test_app/models.py
+++ b/test_utils/test_app/models.py
@@ -1,0 +1,18 @@
+"""
+Models to be used in tests
+"""
+from __future__ import absolute_import, unicode_literals
+
+from opaque_keys.edx.django.models import CourseKeyField
+
+from django.contrib.auth import get_user_model
+from django.db import models
+
+
+class CourseEnrollment(models.Model):
+    """
+    Provides an equivalent for the edx-platform CourseEnrollment model.
+    """
+    is_active = models.BooleanField(default=True)
+    user = models.ForeignKey(get_user_model())
+    course_id = CourseKeyField(max_length=255)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -350,14 +350,14 @@ class CompletionViewTestCase(TestCase):
 
     @XBlock.register_temp_plugin(StubCourse, 'course')
     def test_request_self(self):
-        response = self.client.get(self.list_url + '?username={}'.format(self.test_user.username))
+        response = self.client.get(self.get_list_url(username=self.test_user.username))
         self.assertEqual(response.status_code, 200)
 
     @XBlock.register_temp_plugin(StubCourse, 'course')
     def test_wrong_user(self):
         user = User.objects.create(username='wrong')
         self.client.force_authenticate(user)
-        response = self.client.get(self.list_url + '?username={}'.format(self.test_user.username))
+        response = self.client.get(self.get_list_url(username=self.test_user.username))
         self.assertEqual(response.status_code, 404)
 
     @XBlock.register_temp_plugin(StubCourse, 'course')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -387,7 +387,7 @@ class CompletionViewTestCase(TestCase):
             'next': None,
             'results': [
                 {
-                    'user': 'test_user',
+                    'username': 'test_user',
                     'course_key': 'edX/toy/2012_Fall',
                     'completion': {
                         'earned': 1.0,
@@ -396,7 +396,7 @@ class CompletionViewTestCase(TestCase):
                     },
                 },
                 {
-                    'user': 'test_user_2',
+                    'username': 'test_user_2',
                     'course_key': 'edX/toy/2012_Fall',
                     'completion': {
                         'earned': 3.0,


### PR DESCRIPTION
**Description:** Alters the existing Completion Course Detail View to allow staff users to retrieve all aggregators for all enrolled users in a given course.

**JIRA:** MCKIN-7342, OC-4370

**Testing instructions:**

* In Studio, create 2 courses (e.g. Course A, Course B) with completable units.
* Enroll 2 learners in both courses (e.g. `honor`, `verified`)
* As the first learner, complete several units of Course A and Course B.
* As the second learner, complete units only in Course A.
* As a learner, check the Completion Aggregator API for each course to ensure that you can see only that learner's aggregations using the various URLs.
   Can add `?requested_fields=user` to see the username.
   * list all courses: `<lms_url>/completion-aggregator/v1/course/`
   * course detail: `<lms_url>/completion-aggregator/v1/course/<course_id>`
   * course detail with aggregators: `<lms_url>/completion-aggregator/v1/course/<course_id>/? requested_fields=sequential,chapter,vertical`
* As a `staff` user, check that you can see all the completions and aggregations for all the enrolled users using the detail URLs.
   * course detail for all users: `<lms_url>/completion-aggregator/v1/course/<course_id>`
   * course detail for single user: `<lms_url>/completion-aggregator/v1/course/<course_id>/?username=staff`
   * course detail with aggregators: `<lms_url>/completion-aggregator/v1/course/<course_id>/? requested_fields=sequential,chapter,vertical`
      Note that the requestable `user` field has been added automatically, to distinguish the different users.

**Reviewers:**
- [x] @jcdyer 

**Merge checklist:**
- [x] All reviewers approved
- [ ] CI build is green
- [ ] <strike>Version bumped</strike> -- feature branch, will bump version when that merges to master.
- [ ] <strike>Changelog record added</strike> -- will do when version bumped
- [x] Documentation updated (not only docstrings) -- API documentation is generated from docstrings.
- [ ] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:** - N/A, on feature branch