### PR TITLE
Rewire completion v0 api to use completion-aggregator infrastructure

### DIFF
--- a/completion_aggregator/api/common.py
+++ b/completion_aggregator/api/common.py
@@ -1,0 +1,178 @@
+"""
+Common classes for api views
+"""
+from rest_framework.exceptions import NotFound, ParseError
+from rest_framework.permissions import IsAuthenticated
+
+from django.contrib.auth import get_user_model
+
+from .. import compat
+from ..models import Aggregator
+from ..serializers import course_completion_serializer_factory, is_aggregation_name
+
+User = get_user_model()  # pylint: disable=invalid-name
+
+
+class UserEnrollments(object):
+    """
+    Class for querying user enrollments
+    """
+    def __init__(self, user=None):
+        """
+        Filter active course enrollments for the given user, if any.
+        """
+        self.queryset = compat.course_enrollment_model().objects.filter(is_active=True)
+        if user:
+            self.queryset = self.queryset.filter(user=user)
+
+    def get_course_enrollments(self, course_key):
+        """
+        Return a collection of CourseEnrollments.
+
+        **Parameters**
+
+        course_id:
+            Return all the enrollments for this course.
+
+        The collection must have a .__len__() attribute, be sliceable,
+        and consist of objects that have a user attribute and a course_id
+        attribute.
+        """
+        queryset = self.queryset.filter(course_id=course_key)
+        return queryset.order_by('user')
+
+    def get_course_enrollment(self, course_key):
+        """
+        Return a collection of CourseEnrollments.
+
+        **Parameters**
+
+        course_id:
+            Return all the enrollments for this course.
+
+        The collection must have a .__len__() attribute, be sliceable,
+        and consist of objects that have a user attribute and a course_id
+        attribute.
+        """
+        return self.queryset.get(course_id=course_key)
+
+    def get_enrollments(self):
+        """
+        Return a collection of CourseEnrollments for the current user (if specified).
+
+        The collection must have a .__len__() attribute, be sliceable,
+        and consist of objects that have a user attribute and a course_id
+        attribute.
+        """
+        return self.queryset.order_by('user', 'course_id')
+
+    def is_enrolled(self, course_key):
+        """
+        Return a boolean stating whether user is enrolled in the named course.
+        """
+        return self.queryset.filter(course_id=course_key).exists()
+
+
+class CompletionViewMixin(object):
+    """
+    Common functionality for completion views.
+    """
+
+    _allowed_requested_fields = {'mean', 'username'}
+    permission_classes = (IsAuthenticated,)
+    _effective_user = None
+    _requested_user = None
+
+    @property
+    def authentication_classes(self):  # pragma: no cover
+        """
+        Allow users authenticated via OAuth2 or normal session authentication.
+        """
+        from openedx.core.lib.api import authentication  # pylint: disable=import-error
+        return [
+            authentication.OAuth2AuthenticationAllowInactiveUser,
+            authentication.SessionAuthenticationAllowInactiveUser,
+        ]
+
+    @property
+    def pagination_class(self):  # pragma: no cover
+        """
+        Return the class to use for pagination
+        """
+        try:
+            from edx_rest_framework_extensions import paginators
+        except ImportError:  # paginators are in edx-platform in ginkgo
+            from openedx.core.lib.api import paginators
+
+        return paginators.NamespacedPageNumberPagination
+
+    @property
+    def user(self):
+        """
+        Return the effective user.
+
+        Usually the requesting user, but a staff user can override this.
+        """
+        if self._effective_user:
+            return self._effective_user
+
+        requested_username = self.request.GET.get('username')
+        if not requested_username:
+            user = self.request.user
+            self._requested_user = None
+        else:
+            if self.request.user.is_staff:
+                try:
+                    user = User.objects.get(username=requested_username)
+                except User.DoesNotExist:
+                    raise NotFound()
+            else:
+                if self.request.user.username.lower() == requested_username.lower():
+                    user = self.request.user
+                else:
+                    raise NotFound()
+            self._requested_user = user
+        self._effective_user = user
+        return self._effective_user
+
+    @property
+    def requested_user(self):
+        """
+        Return the requested user.
+
+        Will be None if no specific username was in the request.
+        """
+        # Populating the user property also sets the requested user
+        self.user  # pylint: disable=pointless-statement
+        return self._requested_user
+
+    def get_queryset(self):
+        """
+        Build a base queryset of relevant course-level Aggregator objects.
+        """
+        aggregations = {'course'}
+        aggregations.update(category for category in self.get_requested_fields() if is_aggregation_name(category))
+        return Aggregator.objects.filter(aggregation_name__in=aggregations)
+
+    def get_requested_fields(self):
+        """
+        Parse and return value for requested_fields parameter.
+        """
+        fields = {
+            field for field in self.request.GET.get('requested_fields', '').split(',') if field
+        }
+        invalid = set()
+        for field in fields:
+            if not (is_aggregation_name(field) or field in self._allowed_requested_fields):
+                invalid.add(field)
+
+        if invalid:
+            msg = 'Invalid requested_fields value(s): {}'
+            raise ParseError(msg.format(invalid))
+        return fields
+
+    def get_serializer_class(self, version=1):
+        """
+        Return the appropriate serializer.
+        """
+        return course_completion_serializer_factory(self.get_requested_fields(), version=version)

--- a/completion_aggregator/api/v0/urls.py
+++ b/completion_aggregator/api/v0/urls.py
@@ -1,0 +1,14 @@
+"""
+URLs for the completion API
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^course/$', views.CompletionListView.as_view()),
+    url(r'^course/(?P<course_key>.+)/$', views.CompletionDetailView.as_view()),
+]

--- a/completion_aggregator/api/v0/views.py
+++ b/completion_aggregator/api/v0/views.py
@@ -319,8 +319,6 @@ class CompletionDetailView(CompletionViewMixin, APIView):
             raise NotFound()
         requested_fields = self.get_requested_fields()
         enrollment = UserEnrollments(self.user).get_course_enrollment(course_key)
-        #aggregator_queryset = self.get_queryset().filter(course_key=course_key)
-
         aggregator_queryset = self.get_queryset().filter(course_key=course_key)
 
         # Create the list of aggregate completions to be serialized.

--- a/completion_aggregator/compat.py
+++ b/completion_aggregator/compat.py
@@ -46,6 +46,17 @@ def get_modulestore():
     return modulestore()
 
 
+def get_item(content_key):
+    """
+    Return an item from the modulestore.
+    """
+    from xmodule.modulestore.exceptions import ItemNotFoundError  # pylint: disable=import-error
+    try:
+        get_modulestore().get_item(content_key)
+    except ItemNotFoundError:
+        return False
+
+
 def init_course_blocks(user, course_block_key):
     """
     Return a BlockStructure representing the course.
@@ -115,3 +126,24 @@ def get_affected_aggregators(course_blocks, changed_blocks):
         )
         affected_aggregators.update(block_aggregators)
     return affected_aggregators
+
+
+def get_mobile_only_courses(enrollments):
+    """
+    Return list of courses with mobile available given a list of enrollments.
+    """
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # pylint: disable=import-error
+    course_keys = []
+    for course_enrollment in enrollments:
+        course_keys.append(course_enrollment.course_id)
+    course_overview_list = CourseOverview.objects.filter(id__in=course_keys, mobile_available=True)
+    filtered_course_overview = [overview.id for overview in course_overview_list]
+    return enrollments.filter(course_id__in=filtered_course_overview)
+
+
+def get_course(course_key):
+    """
+    Get course for given key.
+    """
+    from courseware.courses import _get_course  # pylint: disable=import-error
+    return _get_course(course_key)

--- a/completion_aggregator/urls.py
+++ b/completion_aggregator/urls.py
@@ -9,5 +9,6 @@ from django.views.generic import TemplateView
 
 urlpatterns = [
     url(r'^v1/', include('completion_aggregator.api.v1.urls', namespace='completion_api_v1')),
+    url(r'^v0/', include('completion_aggregator.api.v0.urls', namespace='completion_api_v0')),
     url(r'^$', TemplateView.as_view(template_name="completion_aggregator/base.html")),
 ]

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -77,6 +77,10 @@ class StubCompat(object):
         """
         return CourseEnrollment
 
+    def get_mobile_only_courses(self):
+        return MagicMock()
+
+
 
 CourseTreeNode = collections.namedtuple('CourseTreeNode', ['block', 'children'])
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from datetime import timedelta
 
+import ddt
 import six
 from mock import PropertyMock, patch
 from oauth2_provider import models as dot_models
@@ -50,7 +51,8 @@ def _create_oauth2_token(user):
     return dot_access_token.token
 
 
-@patch('completion_aggregator.api.v1.views.compat', StubCompat([]))
+@ddt.ddt
+@patch('completion_aggregator.api.common.compat', StubCompat([]))
 class CompletionViewTestCase(TestCase):
     """
     Test that the CompletionView renders completion data properly.
@@ -58,8 +60,8 @@ class CompletionViewTestCase(TestCase):
 
     course_key = CourseKey.from_string('edX/toy/2012_Fall')
     other_org_course_key = CourseKey.from_string('otherOrg/toy/2012_Fall')
-    list_url = '/v1/course/'
-    detail_url_fmt = '/v1/course/{}/'
+    list_url = '/v{}/course/'
+    detail_url_fmt = '/v{}/course/{}/'
     course_enrollment_model = StubCompat([]).course_enrollment_model()
 
     def setUp(self):
@@ -127,9 +129,40 @@ class CompletionViewTestCase(TestCase):
             course_id=course_id,
         )
 
+    def _get_expected_completion(self, version, earned=1.0, possible=12.0, percent=1/12):
+        """
+        Return completion section based on version.
+        """
+        completion = {
+            'earned':earned,
+            'possible': possible,
+            'percent': percent,
+        }
+        if version == 0:
+            completion['ratio'] = percent
+        return completion
+
+
+    def _get_expected_detail(self, version, values, count=1, previous=None, next_page=None):
+        """
+        Return base result for detail view based on version.
+        """
+        if version == 1:
+            if isinstance(values, dict):
+                values = [values]
+            return {
+                'count': count,
+                'previous': previous,
+                'next': next_page,
+                'results': values
+            }
+        else:
+            return values
+
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    def test_list_view(self):
-        response = self.client.get(self.list_url)
+    def test_list_view(self, version):
+        response = self.client.get(self.list_url.format(version))
         self.assertEqual(response.status_code, 200)
         expected = {
             'count': 1,
@@ -138,17 +171,14 @@ class CompletionViewTestCase(TestCase):
             'results': [
                 {
                     'course_key': 'edX/toy/2012_Fall',
-                    'completion': {
-                        'earned': 1.0,
-                        'possible': 12.0,
-                        'percent': 1 / 12,
-                    },
+                    'completion': self._get_expected_completion(version),
                 }
             ],
         }
         self.assertEqual(response.data, expected)
 
-    def test_list_view_enrolled_no_progress(self):
+    @ddt.data(0, 1)
+    def test_list_view_enrolled_no_progress(self, version):
         """
         Test that the completion API returns a record for each course the user is enrolled in,
         even if no progress records exist yet.
@@ -157,7 +187,7 @@ class CompletionViewTestCase(TestCase):
             user=self.test_user,
             course_id=self.other_org_course_key,
         )
-        response = self.client.get(self.list_url)
+        response = self.client.get(self.list_url.format(version))
         self.assertEqual(response.status_code, 200)
         expected = {
             'count': 2,
@@ -166,28 +196,31 @@ class CompletionViewTestCase(TestCase):
             'results': [
                 {
                     'course_key': 'edX/toy/2012_Fall',
-                    'completion': {
-                        'earned': 0.0,
-                        'possible': None,
-                        'percent': None,
-                    },
+                    'completion': self._get_expected_completion(
+                        version,
+                        earned=0.0,
+                        possible=None,
+                        percent=None,
+                    ),
                 },
                 {
                     'course_key': 'otherOrg/toy/2012_Fall',
-                    'completion': {
-                        'earned': 0.0,
-                        'possible': None,
-                        'percent': None,
-                    },
+                    'completion': self._get_expected_completion(
+                        version,
+                        earned=0.0,
+                        possible=None,
+                        percent=None,
+                    ),
                 }
             ],
         }
         self.assertEqual(response.data, expected)
 
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
     @XBlock.register_temp_plugin(StubSequential, 'sequential')
-    def test_list_view_with_sequentials(self):
-        response = self.client.get(self.get_list_url(requested_fields='sequential'))
+    def test_list_view_with_sequentials(self, version):
+        response = self.client.get(self.get_list_url(version, requested_fields='sequential'))
         self.assertEqual(response.status_code, 200)
         expected = {
             'count': 1,
@@ -196,16 +229,17 @@ class CompletionViewTestCase(TestCase):
             'results': [
                 {
                     'course_key': 'edX/toy/2012_Fall',
-                    'completion': {
-                        'earned': 1.0,
-                        'possible': 12.0,
-                        'percent': 1 / 12,
-                    },
+                    'completion': self._get_expected_completion(version),
                     'sequential': [
                         {
                             'course_key': u'edX/toy/2012_Fall',
                             'block_key': u'i4x://edX/toy/sequential/vertical_sequential',
-                            'completion': {'earned': 1.0, 'possible': 5.0, 'percent': 0.2},
+                            'completion': self._get_expected_completion(
+                                version,
+                                earned=1.0,
+                                possible=5.0,
+                                percent=0.2,
+                            ),
                         },
                     ]
                 }
@@ -213,60 +247,65 @@ class CompletionViewTestCase(TestCase):
         }
         self.assertEqual(response.data, expected)
 
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    def test_detail_view(self):
-        response = self.client.get(self.get_detail_url(six.text_type(self.course_key)))
+    def test_detail_view(self, version):
+        response = self.client.get(self.get_detail_url(version, six.text_type(self.course_key)))
         self.assertEqual(response.status_code, 200)
-        expected = {
-            'count': 1,
-            'previous': None,
-            'next': None,
-            'results': [
-                {
-                    'course_key': 'edX/toy/2012_Fall',
-                    'completion': {
-                        'earned': 1.0,
-                        'possible': 12.0,
-                        'percent': 1 / 12,
-                    },
-                }
-            ]
+        expected_values = {
+            'course_key': 'edX/toy/2012_Fall',
+            'completion': self._get_expected_completion(version)
         }
-
+        expected = self._get_expected_detail(version, expected_values)
         self.assertEqual(response.data, expected)
 
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    def test_detail_view_oauth2(self):
+    def test_detail_view_oauth2(self, version):
         """
         Test the detail view using OAuth2 Authentication
         """
         # Try with no authentication:
         self.client.logout()
-        response = self.client.get(self.get_detail_url(self.course_key))
+        response = self.client.get(self.get_detail_url(version, self.course_key))
         self.assertEqual(response.status_code, 401)
         # Now, try with a valid token header:
         token = _create_oauth2_token(self.test_user)
-        response = self.client.get(self.get_detail_url(self.course_key), HTTP_AUTHORIZATION="Bearer {0}".format(token))
+        response = self.client.get(
+            self.get_detail_url(version, self.course_key),
+            HTTP_AUTHORIZATION="Bearer {0}".format(token)
+        )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['results'][0]['completion']['earned'], 1.0)
+        if version == 0:
+            self.assertEqual(response.data['completion']['earned'], 1.0)
+        else:
+            self.assertEqual(response.data['results'][0]['completion']['earned'], 1.0)
 
-    def test_detail_view_not_enrolled(self):
+    @ddt.data(0, 1)
+    def test_detail_view_not_enrolled(self, version):
         """
         Test that requesting course completions for a course the user is not enrolled in
         will return a 404.
         """
-        response = self.client.get(self.get_detail_url(self.other_org_course_key,
-                                                       username=self.test_user.username))
+        response = self.client.get(
+            self.get_detail_url(
+                version,
+                self.other_org_course_key,
+                username=self.test_user.username
+            )
+        )
         self.assertEqual(response.status_code, 404)
 
-    def test_detail_view_inactive_enrollment(self):
+    @ddt.data(0, 1)
+    def test_detail_view_inactive_enrollment(self, version):
         self.test_enrollment.is_active = False
         self.test_enrollment.save()
-        response = self.client.get(self.get_detail_url(self.course_key))
+        response = self.client.get(self.get_detail_url(version, self.course_key))
         self.assertEqual(response.status_code, 404)
 
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    def test_detail_view_no_completion(self):
+    def test_detail_view_no_completion(self, version):
         """
         Test that requesting course completions for a course which has started, but the user has not yet started,
         will return an empty completion record with its "possible" field filled in.
@@ -275,77 +314,49 @@ class CompletionViewTestCase(TestCase):
             user=self.test_user,
             course_id=self.other_org_course_key,
         )
-        response = self.client.get(self.get_detail_url(self.other_org_course_key))
+        response = self.client.get(self.get_detail_url(version, self.other_org_course_key))
         self.assertEqual(response.status_code, 200)
-        expected = {
-            'count': 1,
-            'previous': None,
-            'next': None,
-            'results': [
-                {
-                    'course_key': 'otherOrg/toy/2012_Fall',
-                    'completion': {
-                        'earned': 0.0,
-                        'possible': None,
-                        'percent': None,
-                    },
-                }
-            ]
+        expected_values = {
+            'course_key': 'otherOrg/toy/2012_Fall',
+            'completion': self._get_expected_completion(version, earned=0.0, possible=None, percent=None),
         }
+        expected = self._get_expected_detail(version, expected_values)
         self.assertEqual(response.data, expected)
 
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
     @XBlock.register_temp_plugin(StubSequential, 'sequential')
-    def test_detail_view_with_sequentials(self):
-        response = self.client.get(self.get_detail_url(self.course_key, requested_fields='sequential'))
+    def test_detail_view_with_sequentials(self, version):
+        response = self.client.get(self.get_detail_url(version, self.course_key, requested_fields='sequential'))
         self.assertEqual(response.status_code, 200)
-        expected = {
-            'count': 1,
-            'previous': None,
-            'next': None,
-            'results': [
+        expected_values = {
+            'course_key': 'edX/toy/2012_Fall',
+            'completion': self._get_expected_completion(version),
+            'sequential': [
                 {
-                    'course_key': 'edX/toy/2012_Fall',
-                    'completion': {
-                        'earned': 1.0,
-                        'possible': 12.0,
-                        'percent': 1 / 12,
-                    },
-                    'sequential': [
-                        {
-                            'course_key': u'edX/toy/2012_Fall',
-                            'block_key': u'i4x://edX/toy/sequential/vertical_sequential',
-                            'completion': {'earned': 1.0, 'possible': 5.0, 'percent': 0.2},
-                        },
-                    ]
-                }
+                    'course_key': u'edX/toy/2012_Fall',
+                    'block_key': u'i4x://edX/toy/sequential/vertical_sequential',
+                    'completion': self._get_expected_completion(version, earned=1.0, possible=5.0, percent=0.2),
+                },
             ]
         }
+        expected = self._get_expected_detail(version, expected_values)
         self.assertEqual(response.data, expected)
 
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    def test_detail_view_staff_requested_user(self):
+    def test_detail_view_staff_requested_user(self, version):
         """
         Test that requesting course completions for a specific user filters out the other enrolled users
         """
         self.client.force_authenticate(self.staff_user)
-        response = self.client.get(self.get_detail_url(self.course_key, username=self.test_user.username))
+        response = self.client.get(self.get_detail_url(version, self.course_key, username=self.test_user.username))
         self.assertEqual(response.status_code, 200)
-        expected = {
-            'count': 1,
-            'previous': None,
-            'next': None,
-            'results': [
-                {
-                    'course_key': 'edX/toy/2012_Fall',
-                    'completion': {
-                        'earned': 1.0,
-                        'possible': 12.0,
-                        'percent': 1 / 12,
-                    },
-                }
-            ]
+        expected_values = {
+            'course_key': 'edX/toy/2012_Fall',
+            'completion': self._get_expected_completion(version)
         }
+        expected = self._get_expected_detail(version, expected_values)
         self.assertEqual(response.data, expected)
 
     @XBlock.register_temp_plugin(StubCourse, 'course')
@@ -379,89 +390,86 @@ class CompletionViewTestCase(TestCase):
         )
 
         self.client.force_authenticate(self.staff_user)
-        response = self.client.get(self.get_detail_url(self.course_key))
+        response = self.client.get(self.get_detail_url(1, self.course_key))
         self.assertEqual(response.status_code, 200)
-        expected = {
-            'count': 2,
-            'previous': None,
-            'next': None,
-            'results': [
-                {
-                    'username': 'test_user',
-                    'course_key': 'edX/toy/2012_Fall',
-                    'completion': {
-                        'earned': 1.0,
-                        'possible': 12.0,
-                        'percent': 1 / 12,
-                    },
-                },
-                {
-                    'username': 'test_user_2',
-                    'course_key': 'edX/toy/2012_Fall',
-                    'completion': {
-                        'earned': 3.0,
-                        'possible': 12.0,
-                        'percent': 0.25,
-                    },
-                },
-            ]
-        }
+        expected_values = [
+            {
+                'username': 'test_user',
+                'course_key': 'edX/toy/2012_Fall',
+                'completion': self._get_expected_completion(1)
+            },
+            {
+                'username': 'test_user_2',
+                'course_key': 'edX/toy/2012_Fall',
+                'completion': self._get_expected_completion(1, earned=3.0, possible=12.0, percent=0.25),
+            },
+        ]
+        expected = self._get_expected_detail(1, expected_values, count=2)
         self.assertEqual(response.data, expected)
 
-    def test_invalid_optional_fields(self):
-        response = self.client.get(self.detail_url_fmt.format('edX/toy/2012_Fall') + '?requested_fields=INVALID')
+    @ddt.data(0, 1)
+    def test_invalid_optional_fields(self, version):
+        response = self.client.get(
+            self.detail_url_fmt.format(version, 'edX/toy/2012_Fall') + '?requested_fields=INVALID'
+        )
         self.assertEqual(response.status_code, 400)
 
-    def test_unauthenticated(self):
+    @ddt.data(0, 1)
+    def test_unauthenticated(self, version):
         self.client.force_authenticate(None)
-        detailresponse = self.client.get(self.get_detail_url(self.course_key))
+        detailresponse = self.client.get(self.get_detail_url(version, self.course_key))
         self.assertEqual(detailresponse.status_code, 401)
-        listresponse = self.client.get(self.get_list_url())
+        listresponse = self.client.get(self.get_list_url(version))
         self.assertEqual(listresponse.status_code, 401)
 
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    def test_request_self(self):
-        response = self.client.get(self.get_list_url(username=self.test_user.username))
+    def test_request_self(self, version):
+        response = self.client.get(self.get_list_url(version, username=self.test_user.username))
         self.assertEqual(response.status_code, 200)
 
-    def test_wrong_user(self):
+    @ddt.data(0, 1)
+    def test_wrong_user(self, version):
         user = User.objects.create(username='wrong')
         self.client.force_authenticate(user)
-        response = self.client.get(self.get_list_url(username=self.test_user.username))
+        response = self.client.get(self.get_list_url(version, username=self.test_user.username))
         self.assertEqual(response.status_code, 404)
 
-    def test_no_user(self):
+    @ddt.data(0, 1)
+    def test_no_user(self, version):
         self.client.logout()
-        response = self.client.get(self.list_url)
+        response = self.client.get(self.get_list_url(version))
         self.assertEqual(response.status_code, 401)
 
+    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    def test_staff_access(self):
+    def test_staff_access(self, version):
         self.client.force_authenticate(self.staff_user)
-        response = self.client.get(self.get_list_url(username=self.test_user.username))
+        response = self.client.get(self.get_list_url(version, username=self.test_user.username))
         self.assertEqual(response.status_code, 200)
-        expected_completion = {'earned': 1.0, 'possible': 12.0, 'percent': 1 / 12}
+        expected_completion = self._get_expected_completion(version)
         self.assertEqual(response.data['results'][0]['completion'], expected_completion)
 
-    def test_staff_access_non_user(self):
+    @ddt.data(0, 1)
+    def test_staff_access_non_user(self, version):
         self.client.force_authenticate(self.staff_user)
-        response = self.client.get(self.get_list_url(username='who-dat'))
+        response = self.client.get(self.get_list_url(version, username='who-dat'))
         self.assertEqual(response.status_code, 404)
 
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    def get_detail_url(self, course_key, **params):
+    def get_detail_url(self, version, course_key, **params):
         """
         Given a course_key and a number of key-value pairs as keyword arguments,
         create a URL to the detail view.
         """
-        return append_params(self.detail_url_fmt.format(six.text_type(course_key)), params)
+        return append_params(self.detail_url_fmt.format(version, six.text_type(course_key)), params)
 
-    def get_list_url(self, **params):
+    def get_list_url(self, version, **params):
         """
         Given a number of key-value pairs as keyword arguments,
         create a URL to the list view.
         """
-        return append_params(self.list_url, params)
+        return append_params(self.list_url.format(version), params)
 
 
 def append_params(base, params):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -129,19 +129,18 @@ class CompletionViewTestCase(TestCase):
             course_id=course_id,
         )
 
-    def _get_expected_completion(self, version, earned=1.0, possible=12.0, percent=1/12):
+    def _get_expected_completion(self, version, earned=1.0, possible=12.0, percent=1 / 12):
         """
         Return completion section based on version.
         """
         completion = {
-            'earned':earned,
+            'earned': earned,
             'possible': possible,
             'percent': percent,
         }
         if version == 0:
             completion['ratio'] = percent
         return completion
-
 
     def _get_expected_detail(self, version, values, count=1, previous=None, next_page=None):
         """


### PR DESCRIPTION
**Description:** Rewire completion v0 api to use completion-aggregator infrastructure

**JIRA:** OC-4522

**Dependencies:**  OC-4528

**Merge deadline:** None

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

Check output of: /api/completion-aggregator/v0/course/
And compare to: /api/completion/v0/course/

Check output of: /api/completion/v0/course/course-course-v1:edX+DemoX+Demo_Course/
And compare to: /api/completion-aggregator/v0/course/course-v1:edX+DemoX+Demo_Course/

**Reviewers:**

- @jcdyer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** Missing migration of [CompletionBlockUpdateView](https://github.com/edx-solutions/edx-platform/blob/master/lms/djangoapps/completion_api/views.py#L441). @jcdyer shouldn't this be on the completion api? instead of here?