### PR TITLE
Add command to convert progress models to BlockCompletions.

### DIFF
--- a/completion_aggregator/management/commands/migrate_progress.py
+++ b/completion_aggregator/management/commands/migrate_progress.py
@@ -1,0 +1,100 @@
+"""
+Migrate CourseModuleCompletion objects to BlockCompletion table.
+"""
+
+import logging
+import time
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ...tasks import aggregation_tasks
+
+try:
+    from progress.models import CourseModuleCompletion
+    PROGRESS_IMPORTED = True
+except ImportError:
+    PROGRESS_IMPORTED = False
+
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Migrate CourseModuleCompletion objects to BlockCompletion table.
+    """
+    def add_arguments(self, parser):
+        """
+        Entry point for subclassed commands to add custom arguments.
+        """
+        parser.add_argument(
+            '--routing-key',
+            dest='routing_key',
+            help='Celery routing key to use.',
+        )
+        parser.add_argument(
+            '--batch-size',
+            help='Maximum number of CourseModuleCompletions to migrate, per celery task. (default: 10000)',
+            default=10000,
+            type=int,
+        )
+        parser.add_argument(
+            '--start-index',
+            help='Offset from which to start processing CourseModuleCompletions. (default: 0)',
+            default=0,
+            type=int,
+        )
+        parser.add_argument(
+            '--stop-index',
+            help='Offset at which to stop processing CourseModuleCompletions. (default: process all)',
+            default=0,
+            type=int,
+        )
+        parser.add_argument(
+            '--delay-between-tasks',
+            help='Amount of time to wait between submitting tasks in seconds.  (default: 0.0)',
+            default=0.0,
+            type=float,
+        )
+
+    def handle(self, *args, **options):
+        if not PROGRESS_IMPORTED:
+            raise CommandError("Unable to import progress models.  Aborting")
+        self._configure_logging(options)
+        task_options = self.get_task_options(options)
+        cmc_count = CourseModuleCompletion.objects.all().count()
+        stop = min(cmc_count, options['stop_index'] or float('inf'))
+        for index in range(options['start_index'], stop, options['batch_size']):
+            batch_size = min(options['batch_size'], stop - index)
+            aggregation_tasks.migrate_batch.apply_async(
+                kwargs={'offset': index, 'batch_size': batch_size},
+                **task_options
+            )
+            time.sleep(options['delay_between_tasks'])
+
+    def get_task_options(self, options):
+        """
+        Return task options for generated celery tasks.
+
+        Currently, this adds a routing key, if provided.
+        """
+        opts = {}
+        if options.get('routing_key'):
+            opts['routing_key'] = options['routing_key']
+        return opts
+
+    def _configure_logging(self, options):
+        """
+        Sets logging levels for this module and the block structure
+        cache module, based on the given the options.
+        """
+        handler = logging.StreamHandler()
+        root_logger = logging.getLogger('')
+        root_logger.addHandler(handler)
+        handler.setFormatter(logging.Formatter('%(levelname)s|%(message)s'))
+
+        if options.get('verbosity') == 0:
+            log_level = logging.WARNING
+        elif options.get('verbosity') >= 1:
+            log_level = logging.INFO
+        log.setLevel(log_level)


### PR DESCRIPTION
**Description:** Provides a management command to create BlockCompletions for every CourseModuleCompletion object in the progress app.

**JIRA:** OC-4528

**Dependencies:** N/A

**Merge deadline:** N/A

**Installation instructions:** In a ginkgo devstack on the development branch, uninstall openedx-completion-aggregator, and reinstall it from this branch.

**Testing instructions:**  

1. Check that there are progress_coursemodulecompletion objects in your database.  If not, browse through a few course sections.
2. Remove all BlockCompletion and Aggregator objects, so you have a couple dozen
3. Run ./manage.py lms --settings=devstack migrate_progress --batch-size=10 --verbosity=2
4. Confirm that Batches are processed, and that BlockCompletions and Aggregators are created.


**Reviewers:**
- [x] @rocioar

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
