### PR TITLE
[MCKIN-7831] Make single-user aggregator endpoint calculate on the fly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ ease installation.  To use in edx-platform, do the following:
         ...
 
     Then configure up a pair of cron jobs to run `./manage.py
-    run_aggregation_service` and `./manage.py run_aggregation_cleanup` as often
+    run_aggregator_service` and `./manage.py run_aggregator_cleanup` as often
     as desired.
 
 Note that if operating on a Hawthorne-or-later release of edx-platform, you may

--- a/completion_aggregator/api/v0/views.py
+++ b/completion_aggregator/api/v0/views.py
@@ -175,12 +175,14 @@ class CompletionListView(CompletionViewMixin, APIView):
             course_key__in=course_keys
         )
 
-        # Create the list of aggregate completions to be serialized.
+        # Create the list of aggregate completions to be serialized,
+        # recalculating any stale completions for this single user.
         completions = [
             AggregatorAdapter(
                 user=self.user,
                 course_key=enrollment.course_id,
                 queryset=aggregator_queryset,
+                recalculate_stale=True,
             ) for enrollment in paginated
         ]
 
@@ -321,11 +323,13 @@ class CompletionDetailView(CompletionViewMixin, APIView):
         enrollment = UserEnrollments(self.user).get_course_enrollment(course_key)
         aggregator_queryset = self.get_queryset().filter(course_key=course_key)
 
-        # Create the list of aggregate completions to be serialized.
+        # Create the list of aggregate completions to be serialized,
+        # recalculating any stale completions for this single user.
         completions = AggregatorAdapter(
             user=enrollment.user,
             course_key=enrollment.course_id,
             queryset=aggregator_queryset,
+            recalculate_stale=True,
         )
 
         # Return the paginated, serialized completions

--- a/completion_aggregator/models.py
+++ b/completion_aggregator/models.py
@@ -242,13 +242,3 @@ class StaleCompletion(TimeStampedModel):
         if self.resolved:
             parts.append('*')
         return ''.join(parts)
-
-    @classmethod
-    def any(cls, course_key, user=None):
-        """
-        Returns whether there are any stale completions for the given course + (optional) user.
-        """
-        stale_objs = cls.objects.filter(course_key=course_key, resolved=False)
-        if user:
-            stale_objs.filter(username=user.username)
-        return stale_objs.exists()

--- a/completion_aggregator/models.py
+++ b/completion_aggregator/models.py
@@ -242,3 +242,13 @@ class StaleCompletion(TimeStampedModel):
         if self.resolved:
             parts.append('*')
         return ''.join(parts)
+
+    @classmethod
+    def any(cls, course_key, user=None):
+        """
+        Returns whether there are any stale completions for the given course + (optional) user.
+        """
+        stale_objs = cls.objects.filter(course_key=course_key, resolved=False)
+        if user:
+            stale_objs.filter(username=user.username)
+        return stale_objs.exists()

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -144,11 +144,10 @@ class AggregatorAdapter(object):
             # Recalculate the aggregations, and use them instead of the given aggregations.
             updater = AggregationUpdater(self.user, self.course_key, compat.get_modulestore())
             updater.update()
-            self.update_aggregators(updater.aggregators.values(), is_stale=False)
-        else:
-            # Given aggregators are not considered stale, so use them.
-            for aggregator in iterable:
-                self.add_aggregator(aggregator)
+            iterable = updater.aggregators.values()
+
+        for aggregator in iterable:
+            self.add_aggregator(aggregator)
 
     @property
     def course(self):

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -117,7 +117,7 @@ class AggregatorAdapter(object):
                         course_key=self.course_key,
                     )
                 ]
-                is_stale = len(stale_completions) > 0
+                is_stale = bool(stale_completions)
 
                 if is_stale:
                     log.info("Resolving %s stale completions for %s+%s",

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -10,14 +10,15 @@ from collections import defaultdict
 
 import six
 from rest_framework import serializers
-from django.db import transaction
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.plugin import PluginMissingError
 
-from .import compat
+from django.db import transaction
+
+from . import compat
 from .models import Aggregator, StaleCompletion
-from .tasks.aggregation_tasks import AggregationUpdater  # FIXME: move this class?
+from .tasks.aggregation_tasks import AggregationUpdater
 
 
 def get_completion_mode(block):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -5,6 +5,7 @@ Test serialization of completion data.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import ddt
+from mock import patch
 from opaque_keys.edx.keys import CourseKey
 from xblock.core import XBlock
 
@@ -13,8 +14,9 @@ from django.test import TestCase
 from django.utils import timezone
 
 from completion_aggregator import models
-from completion_aggregator.serializers import AggregatorAdapter, course_completion_serializer_factory
+from completion_aggregator.serializers import AggregatorAdapter, AggregationUpdater, course_completion_serializer_factory
 from test_utils.test_blocks import StubCourse, StubSequential
+from test_utils.compat import StubCompat
 
 
 class AggregatorAdapterTestCase(TestCase):
@@ -32,7 +34,7 @@ class AggregatorAdapterTestCase(TestCase):
         course_completion, _ = models.Aggregator.objects.submit_completion(
             user=self.test_user,
             course_key=self.course_key,
-            block_key=self.course_key.make_usage_key(block_type='course', block_id='crs'),
+            block_key=self.course_key.make_usage_key(block_type='course', block_id='course'),
             aggregation_name='course',
             earned=4.2,
             possible=9.6,
@@ -59,6 +61,8 @@ class AggregatorAdapterTestCase(TestCase):
 
 
 @ddt.ddt
+@patch('completion_aggregator.serializers.compat', StubCompat([]))
+@patch('completion_aggregator.tasks.aggregation_tasks.compat', StubCompat([]))
 class CourseCompletionSerializerTestCase(TestCase):
     """
     Test that the CourseCompletionSerializer returns appropriate results.
@@ -67,6 +71,62 @@ class CourseCompletionSerializerTestCase(TestCase):
     def setUp(self):
         super(CourseCompletionSerializerTestCase, self).setUp()
         self.test_user = User.objects.create()
+        self.course_key = CourseKey.from_string('course-v1:abc+def+ghi')
+
+    def assert_serialized_completions(self, serializer_cls_args, extra_body):
+        """
+        Ensures that the course completion serializer returns the expected results
+        for this set of submitted completions.
+        """
+        serializer_cls = course_completion_serializer_factory(serializer_cls_args)
+        completions = [
+            models.Aggregator.objects.submit_completion(
+                user=self.test_user,
+                course_key=self.course_key,
+                aggregation_name='course',
+                block_key=self.course_key.make_usage_key(block_type='course', block_id='course'),
+                earned=16.0,
+                possible=19.0,
+                last_modified=timezone.now(),
+            )[0],
+            models.Aggregator.objects.submit_completion(
+                user=self.test_user,
+                course_key=self.course_key,
+                aggregation_name='sequential',
+                block_key=self.course_key.make_usage_key(block_type='sequential', block_id='seq1'),
+                earned=6.0,
+                possible=7.0,
+                last_modified=timezone.now(),
+            )[0],
+            models.Aggregator.objects.submit_completion(
+                user=self.test_user,
+                course_key=self.course_key,
+                aggregation_name='sequential',
+                block_key=self.course_key.make_usage_key(block_type='sequential', block_id='seq2'),
+                earned=10.0,
+                possible=12.0,
+                last_modified=timezone.now(),
+            )[0],
+        ]
+        completion = AggregatorAdapter(
+            user=self.test_user,
+            course_key=self.course_key,
+            queryset=completions,
+        )
+        serial = serializer_cls(completion)
+        expected = {
+            'course_key': str(self.course_key),
+            'completion': {
+                'earned': 16.0,
+                'possible': 19.0,
+                'percent': 16 / 19,
+            },
+        }
+        expected.update(extra_body)
+        self.assertEqual(
+            serial.data,
+            expected,
+        )
 
     @ddt.data(
         [[], {}],
@@ -91,57 +151,32 @@ class CourseCompletionSerializerTestCase(TestCase):
     @ddt.unpack
     @XBlock.register_temp_plugin(StubCourse, 'course')
     @XBlock.register_temp_plugin(StubSequential, 'sequential')
-    def test_serialize_student_progress_object(self, serializer_cls_args, extra_body):
-        serializer_cls = course_completion_serializer_factory(serializer_cls_args)
-        course_key = CourseKey.from_string('course-v1:abc+def+ghi')
-        completions = [
-            models.Aggregator.objects.submit_completion(
-                user=self.test_user,
-                course_key=course_key,
-                aggregation_name='course',
-                block_key=course_key.make_usage_key(block_type='course', block_id='crs'),
-                earned=16.0,
-                possible=19.0,
-                last_modified=timezone.now(),
-            )[0],
-            models.Aggregator.objects.submit_completion(
-                user=self.test_user,
-                course_key=course_key,
-                aggregation_name='sequential',
-                block_key=course_key.make_usage_key(block_type='sequential', block_id='seq1'),
-                earned=6.0,
-                possible=7.0,
-                last_modified=timezone.now(),
-            )[0],
-            models.Aggregator.objects.submit_completion(
-                user=self.test_user,
-                course_key=course_key,
-                aggregation_name='sequential',
-                block_key=course_key.make_usage_key(block_type='sequential', block_id='seq2'),
-                earned=10.0,
-                possible=12.0,
-                last_modified=timezone.now(),
-            )[0],
-        ]
-        completion = AggregatorAdapter(
-            user=self.test_user,
-            course_key=course_key,
-            queryset=completions,
+    @patch.object(AggregationUpdater, 'update')
+    def test_serialize_student_progress_object(self, serializer_cls_args, extra_body, mock_update):
+        self.assert_serialized_completions(serializer_cls_args, extra_body)
+        # no stale completions, so aggregations were not updated
+        assert mock_update.call_count == 0
+
+    @ddt.data(
+        None,
+        'block-v1:abc+def+ghi+type@course+block@course',
+        'block-v1:abc+def+ghi+type@sequential+block@seq1',
+        'block-v1:abc+def+ghi+type@sequential+block@seq2'
+    )
+    @XBlock.register_temp_plugin(StubCourse, 'course')
+    @XBlock.register_temp_plugin(StubSequential, 'sequential')
+    @patch.object(AggregationUpdater, 'update')
+    def test_aggregation_with_stale_completions(self, stale_block_key, mock_update):
+        # Mark a completion as stale for the given block key
+        models.StaleCompletion.objects.create(
+            username=self.test_user.username,
+            course_key=self.course_key,
+            block_key=stale_block_key,
+            force=True,
         )
-        serial = serializer_cls(completion)
-        expected = {
-            'course_key': 'course-v1:abc+def+ghi',
-            'completion': {
-                'earned': 16.0,
-                'possible': 19.0,
-                'percent': 16 / 19,
-            },
-        }
-        expected.update(extra_body)
-        self.assertEqual(
-            serial.data,
-            expected,
-        )
+        self.assert_serialized_completions([], {})
+        # Ensure the aggregations were recalculated due to the stale completion
+        assert mock_update.call_count == 1
 
     @XBlock.register_temp_plugin(StubCourse, 'course')
     def test_zero_possible(self):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -14,9 +14,12 @@ from django.test import TestCase
 from django.utils import timezone
 
 from completion_aggregator import models
-from completion_aggregator.serializers import AggregatorAdapter, AggregationUpdater, course_completion_serializer_factory
-from test_utils.test_blocks import StubCourse, StubSequential
+from completion_aggregator.serializers import (AggregationUpdater, AggregatorAdapter,
+                                               course_completion_serializer_factory)
 from test_utils.compat import StubCompat
+from test_utils.test_blocks import StubCourse, StubSequential
+
+empty_compat = StubCompat([])
 
 
 class AggregatorAdapterTestCase(TestCase):
@@ -61,8 +64,8 @@ class AggregatorAdapterTestCase(TestCase):
 
 
 @ddt.ddt
-@patch('completion_aggregator.serializers.compat', StubCompat([]))
-@patch('completion_aggregator.tasks.aggregation_tasks.compat', StubCompat([]))
+@patch('completion_aggregator.serializers.compat', empty_compat)
+@patch('completion_aggregator.tasks.aggregation_tasks.compat', empty_compat)
 class CourseCompletionSerializerTestCase(TestCase):
     """
     Test that the CourseCompletionSerializer returns appropriate results.

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -161,24 +161,29 @@ class CourseCompletionSerializerTestCase(TestCase):
         assert mock_update.call_count == 0
 
     @ddt.data(
-        None,
-        'block-v1:abc+def+ghi+type@course+block@course',
-        'block-v1:abc+def+ghi+type@sequential+block@seq1',
-        'block-v1:abc+def+ghi+type@sequential+block@seq2'
+        (None, True),
+        (None, False),
+        ('block-v1:abc+def+ghi+type@course+block@course', True),
+        ('block-v1:abc+def+ghi+type@course+block@course', False),
+        ('block-v1:abc+def+ghi+type@sequential+block@seq1', True),
+        ('block-v1:abc+def+ghi+type@sequential+block@seq1', False),
+        ('block-v1:abc+def+ghi+type@sequential+block@seq2', True),
+        ('block-v1:abc+def+ghi+type@sequential+block@seq2', False),
     )
+    @ddt.unpack
     @XBlock.register_temp_plugin(StubCourse, 'course')
     @XBlock.register_temp_plugin(StubSequential, 'sequential')
     @patch.object(AggregationUpdater, 'update')
-    def test_aggregation_with_stale_completions(self, stale_block_key, mock_update):
+    def test_aggregation_with_stale_completions(self, stale_block_key, stale_force, mock_update):
         # Mark a completion as stale for the given block key
         models.StaleCompletion.objects.create(
             username=self.test_user.username,
             course_key=self.course_key,
             block_key=stale_block_key,
-            force=True,
+            force=stale_force,
         )
         self.assert_serialized_completions([], {})
-        # Ensure the aggregations were recalculated due to the stale completion
+        # Ensure the aggregations were recalculated once due to the stale completion
         assert mock_update.call_count == 1
 
     @XBlock.register_temp_plugin(StubCourse, 'course')

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -127,10 +127,11 @@ class CourseCompletionSerializerTestCase(TestCase):
             },
         }
         expected.update(extra_body)
-        self.assertEqual(
-            serial.data,
-            expected,
-        )
+        # Need to allow for rounding error when retrieving the percent from the test database
+        self.assertEqual(serial.data['course_key'], expected['course_key'])
+        self.assertEqual(serial.data['completion']['earned'], expected['completion']['earned'])
+        self.assertEqual(serial.data['completion']['possible'], expected['completion']['possible'])
+        self.assertAlmostEqual(serial.data['completion']['possible'], expected['completion']['possible'], places=14)
 
     @ddt.data(
         [[], {}, False],
@@ -183,6 +184,8 @@ class CourseCompletionSerializerTestCase(TestCase):
 
     @ddt.data(
         (None, True, False),
+        (None, True, True),
+        (None, False, False),
         (None, False, True),
         ('block-v1:abc+def+ghi+type@course+block@course', True, False),
         ('block-v1:abc+def+ghi+type@course+block@course', False, False),

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -37,7 +37,7 @@ class AggregatorAdapterTestCase(TestCase):
         course_completion, _ = models.Aggregator.objects.submit_completion(
             user=self.test_user,
             course_key=self.course_key,
-            block_key=self.course_key.make_usage_key(block_type='course', block_id='course'),
+            block_key=self.course_key.make_usage_key(block_type='course', block_id='crs'),
             aggregation_name='course',
             earned=4.2,
             possible=9.6,


### PR DESCRIPTION
**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** MCKIN-7831, OC-4787

**Dependencies:** None

**Merge deadline:** None

**Installation instructions:** None

**Testing instructions:**

1. Ensure the `completion.enable_completion_tracking` waffle switch is enabled in the lms, and 
    `settings.COMPLETION_AGGREGATOR_ASYNC_AGGREGATION = True`.
1. Create some BlockCompletions, either by browsing a course, or from a `./manage.py lms shell`
1. Verify (from the logging or from the command line) that `StaleCompletions` are being created (but not resolved), and the corresponding `Aggregator` objects are not created/updated.
1. Using a staff account, hit the multi-user API endpoint, and verify (from the logging or from the command line) that:
   1. `StaleCompletions` are not being resolved, and
   1. `Aggregations` are not created/recalculated before they are returned to the API.

   Multi-user API endpoints are (as `staff` user`):
   ```
   GET /api/completion-aggregator/v1/course/<course_key>/
   ```

1. Hit the versioned single-user API endpoint(s) for each course, and verify (from the logging or from the command line) that:
   1. `StaleCompletions` are being resolved, and
   1. `Aggregations` are created/recalculated before they are returned to the API.
   
   single-user API endpoints to test are (as non-staff):
   ```
   GET /api/completion-aggregator/v0/course/
   GET /api/completion-aggregator/v0/course/<course_key>/
   GET /api/completion-aggregator/v1/course/
   GET /api/completion-aggregator/v1/course/<course_key>/
   ```
   or as staff:
   ```
   GET /api/completion-aggregator/v1/course/<course_key>/?username=<user_name>
   ```

**Reviewers:**
- [ ] @jcdyer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
