### PR TITLE
Remove pytest-django from install_requires

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/test.txt requirements/base.in requirements/test.in
 	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
 	# Let tox control the Django version for tests
-	sed '/django==/d' requirements/test.txt > requirements/test.tmp
+	sed '/^django==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
 
 quality: ## check coding style with pycodestyle and pylint

--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.0.1'
+__version__ = '1.1'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements/dev.txt requirements/base.in requirements/dev.in requirements/quality.in
 #
+
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
@@ -17,7 +18,7 @@ certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
-diff-cover==1.0.3
+diff-cover==1.0.4
 distlib==0.2.7            # via caniusepython3
 django-braces==1.13.0     # via django-oauth-toolkit
 django-model-utils==3.1.2
@@ -25,8 +26,8 @@ django-oauth-toolkit==0.12.0
 django==1.10.8
 djangorestframework==3.6.4
 edx-celeryutils==0.1.5
-edx-completion==0.1.7
-edx-i18n-tools==0.4.6
+edx-completion==0.1.8
+edx-i18n-tools==0.4.7
 edx-lint==0.5.5
 edx-opaque-keys[django]==0.4.4
 first==2.0.1              # via pip-tools
@@ -44,7 +45,7 @@ markupsafe==1.0           # via jinja2, xblock
 mccabe==0.6.1             # via pylint
 mysqlclient==1.3.13
 oauthlib==2.0.1           # via django-oauth-toolkit
-packaging==17.1           # via caniusepython3
+packaging==17.1           # via caniusepython3, tox
 path.py==11.0.1           # via edx-i18n-tools
 pbr==4.1.0                # via stevedore
 pip-tools==2.0.2
@@ -57,9 +58,9 @@ pydocstyle==2.1.1
 pygments==2.2.0           # via diff-cover
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.3  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.7.0            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
 python-dateutil==2.7.3    # via xblock
 pytz==2018.5              # via celery, edx-completion, fs, xblock
@@ -70,7 +71,7 @@ six==1.11.0
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.28.0         # via edx-opaque-keys
 tox-battery==0.2
-tox==3.0.0
+tox==3.1.2
 tqdm==4.23.4              # via twine
 twine==1.11.0
 urllib3==1.23             # via requests

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements/doc.txt requirements/base.in requirements/doc.in
 #
+
 alabaster==0.7.11         # via sphinx
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
@@ -24,7 +25,7 @@ djangorestframework==3.6.4
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-celeryutils==0.1.5
-edx-completion==0.1.7
+edx-completion==0.1.8
 edx-opaque-keys[django]==0.4.4
 edx-sphinx-theme==1.3.0
 fs==2.0.24                # via xblock
@@ -43,7 +44,7 @@ packaging==17.1           # via sphinx
 pbr==4.1.0                # via stevedore
 pycparser==2.18           # via cffi
 pygments==2.2.0           # via readme-renderer, sphinx
-pymongo==3.7.0            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
 python-dateutil==2.7.3    # via xblock
 pytz==2018.5              # via babel, celery, edx-completion, fs, xblock
@@ -53,7 +54,7 @@ requests==2.19.1          # via sphinx
 restructuredtext-lint==1.1.3  # via doc8
 six==1.11.0
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.7.5
+sphinx==1.7.6
 sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.28.0         # via doc8, edx-opaque-keys
 urllib3==1.23             # via requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements/quality.txt requirements/quality.in
 #
+
 argparse==1.4.0           # via caniusepython3
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery
 backports.functools-lru-cache==1.5  # via caniusepython3
@@ -23,7 +24,7 @@ pycodestyle==2.4.0
 pydocstyle==2.1.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.3  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.2.0          # via packaging
 requests==2.19.1          # via caniusepython3

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 ddt			  # Provides test parameterization
 django-model-utils        # Provides TimeStampedModel abstract base class
 mock
+pytest
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 redis

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements/test.txt requirements/base.in requirements/test.in
 #
+
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
@@ -12,13 +13,13 @@ attrs==18.1.0             # via pytest
 billiard==3.3.0.23        # via celery
 celery==3.1.18
 coverage==4.5.1           # via pytest-cov
-ddt==1.1.3
+ddt==1.2.0
 django-braces==1.13.0     # via django-oauth-toolkit
 django-model-utils==3.1.2
 django-oauth-toolkit==0.12.0
 djangorestframework==3.6.4
 edx-celeryutils==0.1.5
-edx-completion==0.1.7
+edx-completion==0.1.8
 edx-opaque-keys[django]==0.4.4
 fs==2.0.24                # via xblock
 jsonfield==2.0.2          # via edx-celeryutils
@@ -32,9 +33,10 @@ oauthlib==2.0.1           # via django-oauth-toolkit
 pbr==4.1.0                # via mock, stevedore
 pluggy==0.6.0             # via pytest
 py==1.5.4                 # via pytest
-pymongo==3.7.0            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pytest-cov==2.5.1
-pytest==3.6.3             # via pytest-cov, pytest-django
+pytest-django==3.3.2
+pytest==3.6.3
 python-dateutil==2.7.3    # via xblock
 pytz==2018.5              # via celery, edx-completion, fs, xblock
 pyyaml==3.13              # via xblock

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,16 +4,19 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
+
 certifi==2018.4.16        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==4.5.1           # via codecov
 idna==2.7                 # via requests
+packaging==17.1           # via tox
 pluggy==0.6.0             # via tox
 py==1.5.4                 # via tox
+pyparsing==2.2.0          # via packaging
 requests==2.19.1          # via codecov
-six==1.11.0               # via tox
+six==1.11.0               # via packaging, tox
 tox-battery==0.2
-tox==3.0.0
+tox==3.1.2
 urllib3==1.23             # via requests
 virtualenv==16.0.0        # via tox

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "Django>=1.8,<1.12",
         "django-model-utils>=2.0",
         "djangorestframework",
-        "pytest-django",
         "XBlock",
         "celery>=3.1",
         "edx-celeryutils>=0.1.5",


### PR DESCRIPTION
**Description:** 

* Move pytest-django from setup.py to requirements files.  This fixes a problem running tests in edx-platform.
* Upgrade requirements.
* Bump aggregator version to 1.1

**JIRA:** [OC-4767](https://tasks.opencraft.com/browse/OC-4767)

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happend instead - check failed.

**Reviewers:**
- [ ] @rocioar 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
