### PR TITLE
Use mysql on insert duplicate update query to reduce number of aggregation query per course.

### DIFF
--- a/completion_aggregator/utils.py
+++ b/completion_aggregator/utils.py
@@ -1,8 +1,13 @@
 """
 Various utility functionality.
 """
-
+import django
 from django.contrib.auth import get_user_model
+from django.utils import timezone
+from django.utils.translation import ugettext as _
+
+DJANGO_MAJOR_VERSION = django.VERSION[0]
+DJANGO_MINOR_VERSION = django.VERSION[1]
 
 
 class BagOfHolding(object):
@@ -28,3 +33,28 @@ def get_active_users(course_key):
     Return a list of users that have Aggregators in the course.
     """
     return get_user_model().objects.filter(aggregator__course_key=course_key).distinct()
+
+
+def make_datetime_timezone_unaware(date):
+    """
+    Return a timezone unaware(localize) version of the datetime instance.
+    """
+    # pylint: disable=line-too-long
+    # Ref: https://github.com/django/django/commit/e707e4c709c2e3f2dad69643eb838f87491891f8#diff-af003fcfed7cfbdeb396f8647ed0f92fR258
+    # pylint: enable=line-too-long
+    if DJANGO_MAJOR_VERSION >= 1 and DJANGO_MINOR_VERSION >= 10:
+        date = date.astimezone(timezone.utc).replace(tzinfo=None)
+    return date
+
+
+def get_percent(earned, possible):
+    """
+    Return percentage completion value on the basis of earned and possible.
+    """
+    if earned > possible:
+        raise ValueError(_('Earned cannot be greater than the possible value.'))
+    if possible > 0.0:
+        percent = earned / possible
+    else:
+        percent = 1.0
+    return percent

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -197,3 +197,21 @@ class AggregatorTestCase(TestCase):
         self.assertEqual(is_new, is_second_obj_new)
         if is_second_obj_new:
             self.assertNotEqual(obj.id, new_obj.id)
+
+    @ddt.data(
+        (BLOCK_KEY_OBJ, 'course', 0.5, 1, 0.5),
+    )
+    @ddt.unpack
+    def test_get_values(self, block_key_obj, aggregate_name, earned, possible, expected_percent):
+        aggregator = Aggregator(
+            user=self.user,
+            course_key=block_key_obj.course_key,
+            block_key=block_key_obj,
+            aggregation_name=aggregate_name,
+            earned=earned,
+            possible=possible,
+            last_modified=now(),
+        )
+        values = aggregator.get_values()
+        self.assertEqual(values['user'], self.user.id)
+        self.assertEqual(values['percent'], expected_percent)

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for the `openedx-completion-aggregator` utils module.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import ddt
+import pytest
+
+from django.test import TestCase
+
+from completion_aggregator.utils import get_percent
+
+
+@ddt.ddt
+class GetPercentTestCase(TestCase):
+    """
+    Tests of the `get_percent` function
+    """
+
+    def test_get_percent_with_invalid_values(self):
+        with pytest.raises(ValueError):
+            get_percent(1.1, 0.9)
+
+    @ddt.data(
+        (0.5, 1, 0.5),
+        (0.5, 2, 0.25),
+    )
+    @ddt.unpack
+    def test_get_percent_with_valid_values(self, earned, possible, expected_percentage):
+        percentage = get_percent(earned, possible)
+        self.assertEqual(percentage, expected_percentage)


### PR DESCRIPTION

**Description:** 

This PR adds support to reduce the number of queries made to insert aggregation data per course. It uses Mysql Insert on Duplicate Update query, so that a single query can be sent which contains manyu rows of aggregation data

**JIRA:** [OC-4844](https://tasks.opencraft.com/browse/OC-4844)

**Dependencies:** NA

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

Tests should pass

**Reviewers:**
- [ ] @symbolist 
- [ ] @jcdyer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 
* Functions like `AggregatorManager.validate` and the logic to calculate percentage completion are duplicated in `AggregationUpdater._is_aggregator_data_valid` and `utils.get_percent`. I was not sure where to keep them or convert the existing method to static method or so.