### PR TITLE
Handle aggregation for courses with bad data

### DIFF
--- a/completion_aggregator/compat.py
+++ b/completion_aggregator/compat.py
@@ -46,15 +46,12 @@ def get_modulestore():
     return modulestore()
 
 
-def get_item(content_key):
+def get_item_not_found_error():
     """
-    Return an item from the modulestore.
+    Return ItemNotFoundError.
     """
     from xmodule.modulestore.exceptions import ItemNotFoundError  # pylint: disable=import-error
-    try:
-        get_modulestore().get_item(content_key)
-    except ItemNotFoundError:
-        return False
+    return ItemNotFoundError
 
 
 def init_course_blocks(user, course_block_key):

--- a/completion_aggregator/tasks/aggregation_tasks.py
+++ b/completion_aggregator/tasks/aggregation_tasks.py
@@ -108,8 +108,14 @@ def _update_aggregators(user, course_key, block_keys=frozenset(), force=False):
             If True, update aggregators even if they are up-to-date.
 
     """
-    updater = AggregationUpdater(user, course_key, compat.get_modulestore())
-    updater.update(block_keys, force)
+    try:
+        updater = AggregationUpdater(user, course_key, compat.get_modulestore())
+    except compat.get_item_not_found_error():
+        log.exception("Course not found in modulestore.  Skipping aggregation for %s/%s.", user, course_key)
+    except TypeError:
+        log.exception("Could not parse modulestore data.  Skipping aggregation for %s/%s.", user, course_key)
+    else:
+        updater.update(block_keys, force)
 
 
 class AggregationUpdater(object):

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -80,6 +80,11 @@ class StubCompat(object):
     def get_mobile_only_courses(self):
         return MagicMock()
 
+    def get_item_not_found_error(self):
+        """
+        Use ValueError as a replacement for modulestore's ItemNotFoundError
+        """
+        return ValueError
 
 
 CourseTreeNode = collections.namedtuple('CourseTreeNode', ['block', 'children'])

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ passenv =
     EDXAGG_MYSQL_PASSWORD
 
 [testenv:docs]
+basepython = python3.5
 setenv =
     DJANGO_SETTINGS_MODULE = test_settings
     PYTHONPATH = {toxinidir}
@@ -53,6 +54,7 @@ commands =
     python setup.py check --restructuredtext --strict
 
 [testenv:quality]
+basepython = python3.5
 whitelist_externals =
     make
     rm


### PR DESCRIPTION
Some courses no longer exist, and some have bad modulestore data that raises TypeErrors (in course blocks parsing).

**Description:** This handles errors gracefully when trying to load and parse modulestore data.  In those cases, we log a warning, and abort gracefully.

**JIRA:** [OC-5174](https://tasks.opencraft.com/browse/OC-5174)

**Dependencies:** 

**Merge deadline:** ASAP.  This is needed for completion rollout.

**Installation instructions:** List any non-trivial installation Link to JIRA ticket
instructions.

**Testing instructions:**

1. Create a stale completion for a course that doesn't exist.
2. Run completions.
3. Verify that an error gets logged, but the task doesn't crash.

**Reviewers:**
- [ ] @xitij2000 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** N/A
