### PR TITLE
Update unviewed aggregators to return 0 percent completion.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.3.1'
+__version__ = '1.4'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -178,7 +178,7 @@ class AggregatorAdapter(object):
             aggregation_name='course',
             earned=0.0,
             possible=None,
-            percent=None,
+            percent=0.0,
         )
 
     @property

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -316,7 +316,7 @@ class CourseCompletionSerializerTestCase(TestCase):
             {
                 'earned': 0.0,
                 'possible': None,
-                'percent': None,
+                'percent': 0.0,
             },
         )
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -231,7 +231,7 @@ class CompletionViewTestCase(TestCase):
                         version,
                         earned=0.0,
                         possible=None,
-                        percent=None,
+                        percent=0.0,
                     ),
                 },
                 {
@@ -240,7 +240,7 @@ class CompletionViewTestCase(TestCase):
                         version,
                         earned=0.0,
                         possible=None,
-                        percent=None,
+                        percent=0.0,
                     ),
                 }
             ],
@@ -376,7 +376,7 @@ class CompletionViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         expected_values = {
             'course_key': 'otherOrg/toy/2012_Fall',
-            'completion': self._get_expected_completion(version, earned=0.0, possible=None, percent=None),
+            'completion': self._get_expected_completion(version, earned=0.0, possible=None, percent=0.0),
         }
         expected = self._get_expected_detail(version, expected_values)
         self.assertEqual(response.data, expected)


### PR DESCRIPTION
**Description:** Return 0 instead of None if the learner has no aggregators.

**JIRA:** [MCKIN-8468](https://edx-wiki.atlassian.net/browse/MCKIN-8468), [BEBOP-316](https://tasks.opencraft.com/browse/BEBOP-316)

**Dependencies:** None

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:**

1. Enroll a user in a course.  
2. DO NOT VISIT THE COURSE
3. Request completions for the user.
4. See value returned as 0.0.
5. Verify that apros doesn't error as described in the ticket.

**Reviewers:**
- [ ] @xitij2000  

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** None
