### PR TITLE
Fix error when getting means for course without aggregators

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.4'
+__version__ = '1.4.1'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.4.1'
+__version__ = '1.5'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -254,6 +254,24 @@ class CourseCompletionSerializer(serializers.Serializer):
         """
         return obj.user.username
 
+    def _calculate_mean(self, obj):
+        """
+        Caclulate mean completion percent for all enrolled users.
+        """
+        enrollments = compat.get_users_enrolled_in(obj.course_key)
+        enrollment_count = enrollments.count()
+        if enrollment_count == 0:
+            return 0.
+
+        total = Aggregator.objects.filter(
+            course_key=obj.course_key,
+            aggregation_name='course',
+        ).aggregate(Sum('percent')).get('percent__sum', 0.)
+
+        if total is None:
+            return 0.
+        return total / enrollment_count
+
     def get_mean(self, obj):
         """
         Return the mean completion percent for all enrolled users.
@@ -261,15 +279,7 @@ class CourseCompletionSerializer(serializers.Serializer):
         mean_cache_key = MEAN_CACHE_KEY_FORMAT.format(course_key=obj.course_key)
         mean = cache.get(mean_cache_key)
         if mean is None:
-            enrollments = compat.get_users_enrolled_in(obj.course_key)
-            enrollment_count = enrollments.count()
-            if enrollment_count == 0:
-                return 0.
-
-            mean = Aggregator.objects.filter(
-                course_key=obj.course_key,
-                aggregation_name='course',
-            ).aggregate(Sum('percent')).get('percent__sum', 0.) / enrollment_count
+            mean = self._calculate_mean(obj)
             cache.set(mean_cache_key, mean, 30 * 60)  # Cache for 30 mins
         return mean
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -254,6 +254,17 @@ class CourseCompletionSerializerTestCase(TestCase):
         )
 
     @XBlock.register_temp_plugin(StubCourse, 'course')
+    def test_mean_with_no_completions(self):
+        # A course that has no aggregators recorded.
+        course_key = CourseKey.from_string('course-v1:abc+def+ghj')
+        serial = course_completion_serializer_factory(['mean'])(AggregatorAdapter(
+            user=self.test_user,
+            course_key=course_key,
+            aggregators=[],
+        ), requested_fields={'mean'})
+        self.assertAlmostEqual(serial.data['mean'], 0)
+
+    @XBlock.register_temp_plugin(StubCourse, 'course')
     def test_mean(self):
         course_key = CourseKey.from_string('course-v1:abc+def+ghi')
         data = [


### PR DESCRIPTION
**Description:** 

Fixes error that occurs when you ask for mean value in a course without any Aggregators. 

**Reviewers:**
- [ ] @jcdyer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
