### PR TITLE
Recalculate serializers without saving to database.

### DIFF
--- a/completion_aggregator/compat.py
+++ b/completion_aggregator/compat.py
@@ -128,7 +128,7 @@ def get_affected_aggregators(course_blocks, changed_blocks):
             AggregatorAnnotationTransformer,
             AggregatorAnnotationTransformer.AGGREGATORS
         )
-        affected_aggregators.update(block_aggregators)
+        affected_aggregators.update(block_aggregators or [])
     return affected_aggregators
 
 

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from collections import defaultdict
 
-import six 
+import six
 from rest_framework import serializers
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
@@ -20,7 +20,7 @@ from django.db.models import Sum
 
 from . import compat
 from .models import Aggregator, StaleCompletion
-from .tasks.aggregation_tasks import AggregationUpdater, calculate_updated_aggregators
+from .tasks.aggregation_tasks import calculate_updated_aggregators
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +115,8 @@ class AggregatorAdapter(object):
                     course_key=self.course_key,
                 )
             }
-        else: stale_blocks = []
+        else:
+            stale_blocks = []
 
         self.update_aggregators(aggregators or [], stale_blocks=stale_blocks)
 
@@ -151,8 +152,8 @@ class AggregatorAdapter(object):
             updated_aggregators = calculate_updated_aggregators(
                 self.user,
                 self.course_key,
-                block_keys=stale_blocks,
-                force=True,
+                changed_blocks=stale_blocks,
+                force=False,
             )
             updated_dict = {aggregator.block_key: aggregator for aggregator in updated_aggregators}
             iterable = (updated_dict.get(agg.block_key, agg) for agg in iterable)

--- a/completion_aggregator/tasks/aggregation_tasks.py
+++ b/completion_aggregator/tasks/aggregation_tasks.py
@@ -117,7 +117,7 @@ def _update_aggregators(user, course_key, block_keys=frozenset(), force=False):
     else:
         updater.update(block_keys, force)
 
-def calculate_updated_aggregators(user, course_key, block_keys=frozenset(), force=False):
+def calculate_updated_aggregators(user, course_key, changed_blocks=frozenset(), force=False):
     try:
         updater = AggregationUpdater(user, course_key, compat.get_modulestore())
     except compat.get_item_not_found_error():
@@ -127,7 +127,7 @@ def calculate_updated_aggregators(user, course_key, block_keys=frozenset(), forc
         log.exception("Could not parse modulestore data.  Skipping aggregation for %s/%s.", user, course_key)
         return []
     else:
-        return updater.calculate_updated_aggregators(block_keys, force)
+        return updater.calculate_updated_aggregators(changed_blocks, force)
 
 
 class AggregationUpdater(object):

--- a/completion_aggregator/tasks/aggregation_tasks.py
+++ b/completion_aggregator/tasks/aggregation_tasks.py
@@ -117,6 +117,7 @@ def _update_aggregators(user, course_key, block_keys=frozenset(), force=False):
     else:
         updater.update(block_keys, force)
 
+
 def calculate_updated_aggregators(user, course_key, changed_blocks=frozenset(), force=False):
     try:
         updater = AggregationUpdater(user, course_key, compat.get_modulestore())

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -80,4 +80,4 @@ web-fragments==0.2.2      # via xblock
 webob==1.8.2              # via xblock
 wheel==0.31.1
 wrapt==1.10.11            # via astroid
-xblock==1.2.1
+xblock==1.2.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -61,4 +61,4 @@ urllib3==1.23             # via requests
 web-fragments==0.2.2      # via xblock
 webencodings==0.5.1       # via html5lib
 webob==1.8.2              # via xblock
-xblock==1.2.1
+xblock==1.2.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -45,4 +45,4 @@ six==1.11.0
 stevedore==1.28.0         # via edx-opaque-keys
 web-fragments==0.2.2      # via xblock
 webob==1.8.2              # via xblock
-xblock==1.2.1
+xblock==1.2.2

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -15,8 +15,8 @@ from django.test import TestCase
 from django.utils import timezone
 
 from completion_aggregator import models
-from completion_aggregator.serializers import (AggregationUpdater, AggregatorAdapter,
-                                               course_completion_serializer_factory)
+from completion_aggregator.serializers import AggregatorAdapter, course_completion_serializer_factory
+from completion_aggregator.tasks.aggregation_tasks import AggregationUpdater
 from test_utils.compat import StubCompat
 from test_utils.test_blocks import StubCourse, StubSequential
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -204,8 +204,8 @@ class CourseCompletionSerializerTestCase(TestCase):
     @ddt.unpack
     @XBlock.register_temp_plugin(StubCourse, 'course')
     @XBlock.register_temp_plugin(StubSequential, 'sequential')
-    @patch.object(AggregationUpdater, 'update')
-    def test_aggregation_recalc_stale_completions(self, stale_block_key, stale_force, recalc_stale, mock_update):
+    @patch.object(AggregationUpdater, 'calculate_updated_aggregators')
+    def test_aggregation_recalc_stale_completions(self, stale_block_key, stale_force, recalc_stale, mock_calculate):
         """
         Ensure that requesting aggregation when recalculating stale completions causes the aggregations to be
         recalculated once, and the stale completion resolved.
@@ -221,10 +221,10 @@ class CourseCompletionSerializerTestCase(TestCase):
         assert models.StaleCompletion.objects.filter(resolved=False).count() == 1
         self.assert_serialized_completions([], {}, recalc_stale)
         if recalc_stale:
-            assert mock_update.call_count == 1
-            assert models.StaleCompletion.objects.filter(resolved=False).count() == 0
+            assert mock_calculate.call_count == 1
+            assert models.StaleCompletion.objects.filter(resolved=False).count() == 1
         else:
-            assert mock_update.call_count == 0
+            assert mock_calculate.call_count == 0
             assert models.StaleCompletion.objects.filter(resolved=False).count() == 1
 
     @XBlock.register_temp_plugin(StubCourse, 'course')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -306,7 +306,7 @@ class CompletionViewTestCase(TestCase):
     def test_detail_view_stale_completion(self, version, mock_calculate):
         """
         Ensure that a stale completion causes the aggregations to be recalculated once.
-        
+
         Verify that the stale completion not resolved.
         """
         models.StaleCompletion.objects.create(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -22,7 +22,7 @@ from django.utils import timezone
 
 from completion_aggregator import models
 from completion_aggregator.api.v1.views import CompletionViewMixin
-from completion_aggregator.serializers import AggregationUpdater
+from completion_aggregator.tasks.aggregation_tasks import AggregationUpdater
 from test_utils.compat import StubCompat
 from test_utils.test_blocks import StubCourse, StubSequential
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -192,10 +192,11 @@ class CompletionViewTestCase(TestCase):
 
     @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    @patch.object(AggregationUpdater, 'update')
-    def test_list_view_stale_completion(self, version, mock_update):
+    @patch.object(AggregationUpdater, 'calculate_updated_aggregators')
+    def test_list_view_stale_completion(self, version, mock_calculate):
         """
-        Ensure that a stale completion causes the aggregations to be recalculated once, and stale completion resolved.
+        Ensure that a stale completion causes the aggregations to be recalculated, but not updated in the db,
+        and stale completion is not resolved.
         """
         models.StaleCompletion.objects.create(
             username=self.test_user.username,
@@ -205,8 +206,8 @@ class CompletionViewTestCase(TestCase):
         )
         assert models.StaleCompletion.objects.filter(resolved=False).count() == 1
         self.assert_expected_list_view(version)
-        assert mock_update.call_count == 1
-        assert models.StaleCompletion.objects.filter(resolved=False).count() == 0
+        assert mock_calculate.call_count == 1
+        assert models.StaleCompletion.objects.filter(resolved=False).count() == 1
 
     @ddt.data(0, 1)
     def test_list_view_enrolled_no_progress(self, version):
@@ -301,10 +302,12 @@ class CompletionViewTestCase(TestCase):
 
     @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
-    @patch.object(AggregationUpdater, 'update')
-    def test_detail_view_stale_completion(self, version, mock_update):
+    @patch.object(AggregationUpdater, 'calculate_updated_aggregators')
+    def test_detail_view_stale_completion(self, version, mock_calculate):
         """
-        Ensure that a stale completion causes the aggregations to be recalculated once, and stale completion resolved.
+        Ensure that a stale completion causes the aggregations to be recalculated once.
+        
+        Verify that the stale completion not resolved.
         """
         models.StaleCompletion.objects.create(
             username=self.test_user.username,
@@ -314,8 +317,8 @@ class CompletionViewTestCase(TestCase):
         )
         assert models.StaleCompletion.objects.filter(resolved=False).count() == 1
         self.assert_expected_detail_view(version)
-        assert mock_update.call_count == 1
-        assert models.StaleCompletion.objects.filter(resolved=False).count() == 0
+        assert mock_calculate.call_count == 1
+        assert models.StaleCompletion.objects.filter(resolved=False).count() == 1
 
     @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')


### PR DESCRIPTION
**Description:** Maintain recalculation of stale blocks on single-user views, but do not save to db.  Resolves some db locking issues.

**JIRA:** [MCKIN-8483](https://edx-wiki.atlassian.net/browse/MCKIN-8483) [BB-330](https://tasks.opencraft.com/browse/BB-330)

**Dependencies:** N/A

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:**

**Reviewers:**
- [ ] @xitij2000 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
