### PR TITLE
Ensure new percent is included in live-updated aggregators.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.1'
+__version__ = '1.5.2'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -148,14 +148,11 @@ class AggregatorAdapter(object):
         """
         if is_stale:
             log.info("Stale completions found for %s+%s, recalculating.", self.user, self.course_key)
-            updated_aggregators = calculate_updated_aggregators(
+            iterable = calculate_updated_aggregators(
                 self.user,
                 self.course_key,
                 force=True,
             )
-            updated_dict = {aggregator.block_key: aggregator for aggregator in updated_aggregators}
-            iterable = (updated_dict.get(agg.block_key, agg) for agg in iterable)
-
         for aggregator in iterable:
             self.add_aggregator(aggregator)
 

--- a/completion_aggregator/tasks/aggregation_tasks.py
+++ b/completion_aggregator/tasks/aggregation_tasks.py
@@ -233,7 +233,10 @@ class AggregationUpdater(object):
             if modified is not None:
                 last_modified = max(last_modified, modified)
         if self._aggregator_needs_update(block, last_modified, force):
-
+            if total_possible == 0.0:
+                percent = 1.0
+            else:
+                percent = total_earned / total_possible
             Aggregator.objects.validate(self.user, self.course_key, block)
             if block not in self.aggregators:
                 aggregator = Aggregator(
@@ -243,6 +246,7 @@ class AggregationUpdater(object):
                     aggregation_name=block.block_type,
                     earned=total_earned,
                     possible=total_possible,
+                    percent=percent,
                     last_modified=last_modified,
                 )
                 self.aggregators[block] = aggregator
@@ -250,6 +254,7 @@ class AggregationUpdater(object):
                 aggregator = self.aggregators[block]
                 aggregator.earned = total_earned
                 aggregator.possible = total_possible
+                aggregator.percent = percent
                 aggregator.last_modified = last_modified
                 aggregator.modified = timezone.now()
             self.updated_aggregators.append(aggregator)

--- a/test_settings.py
+++ b/test_settings.py
@@ -20,7 +20,7 @@ def root(*args):
 
 AUTH_USER_MODEL = 'auth.User'
 CELERY_ALWAYS_EAGER = True
-COMPLETION_AGGREGATOR_BLOCK_TYPES = {'course', 'chapter'}
+COMPLETION_AGGREGATOR_BLOCK_TYPES = {'course', 'chapter', 'sequential'}
 COMPLETION_AGGREGATOR_ASYNC_AGGREGATION = True
 
 DATABASES = {
@@ -63,6 +63,12 @@ REST_FRAMEWORK = {
 
 ROOT_URLCONF = 'completion_aggregator.urls'
 SECRET_KEY = 'insecure-secret-key'
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
 USE_TZ = True
 
 # pylint: disable=unused-import,wrong-import-position

--- a/test_utils/test_blocks.py
+++ b/test_utils/test_blocks.py
@@ -20,3 +20,10 @@ class StubSequential(XBlock):
     Stub sequential block
     """
     completion_mode = XBlockCompletionMode.AGGREGATOR
+
+
+class StubHTML(XBlock):
+    """
+    Stub HTML block
+    """
+    completion_mode = XBlockCompletionMode.COMPLETABLE


### PR DESCRIPTION
**Description:** When live-calculating aggregators, the percent field was not getting populated.  Populate it.

**JIRA:** 

Fixes:
* MCKIN-8474
* BB-365

Affects:
* MCKIN-8099

**Dependencies:** N/A 

**Merge deadline:** ASAP

**Installation instructions:** Usual completion flags, included COMPLETION_AGGREGATOR_ASYNC_AGGREGATION = True

**Testing instructions:**

1. Complete some blocks.
2. Load single-course completion api for one user.  
3. See that percent is 0.0, even when earned is not 0.0.
4. install this branch.
5. Repeat step 2.
6. See that percent > 0.0 when earned > 0.0.

**Reviewers:**
- [ ] @xitij2000 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
