### PR TITLE
[BB-370] Non staff users now get 403 error when trying to request aggregator data about other users

### DIFF
--- a/completion_aggregator/api/common.py
+++ b/completion_aggregator/api/common.py
@@ -1,7 +1,7 @@
 """
 Common classes for api views
 """
-from rest_framework.exceptions import NotFound, ParseError
+from rest_framework.exceptions import NotFound, ParseError, PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 
 from django.contrib.auth import get_user_model
@@ -120,8 +120,11 @@ class CompletionViewMixin(object):
 
         requested_username = self.request.GET.get('username')
         if not requested_username:
-            user = self.request.user
-            self._requested_user = None
+            if self.request.user.is_staff:
+                user = self.request.user
+                self._requested_user = None
+            else:
+                raise PermissionDenied()
         else:
             if self.request.user.is_staff:
                 try:
@@ -132,7 +135,7 @@ class CompletionViewMixin(object):
                 if self.request.user.username.lower() == requested_username.lower():
                     user = self.request.user
                 else:
-                    raise NotFound()
+                    raise PermissionDenied()
             self._requested_user = user
         self._effective_user = user
         return self._effective_user

--- a/completion_aggregator/api/v1/views.py
+++ b/completion_aggregator/api/v1/views.py
@@ -68,8 +68,8 @@ class CompletionListView(CompletionViewMixin, APIView):
 
         username (optional):
             The username of the specified user for whom the course data is
-            being accessed.  If not specified, this defaults to the requesting
-            user.
+            being accessed.  If not specified, this will show data for all users
+            if performed by a staff user, otherwise it will throw a 403 Error.
 
         requested_fields (optional):
             A comma separated list of extra data to be returned.  This can be
@@ -258,10 +258,11 @@ class CompletionDetailView(CompletionViewMixin, APIView):
 
         username (optional):
             The username of the specified user for whom the course data is being
-            accessed.
+            accessed. If a non-staff users tries to access another users data they
+            will get a 403 Error.
             If omitted, and the requesting user has staff access, then data for
             all enrolled users is returned. If the requesting user does not have
-            staff access, then only data for the requesting user is returned.
+            staff access, it will return a 403 Error.
 
         requested_fields (optional):
             A comma separated list of extra data to be returned.  This can be

--- a/completion_aggregator/api/v1/views.py
+++ b/completion_aggregator/api/v1/views.py
@@ -68,8 +68,8 @@ class CompletionListView(CompletionViewMixin, APIView):
 
         username (optional):
             The username of the specified user for whom the course data is
-            being accessed.  If not specified, this will show data for all users
-            if performed by a staff user, otherwise it will throw a 403 Error.
+            being accessed. If not specified, this will show data for all users
+            if requested by a staff user, otherwise it will throw a 403 Error.
 
         requested_fields (optional):
             A comma separated list of extra data to be returned.  This can be
@@ -258,7 +258,7 @@ class CompletionDetailView(CompletionViewMixin, APIView):
 
         username (optional):
             The username of the specified user for whom the course data is being
-            accessed. If a non-staff users tries to access another users data they
+            accessed. If a non-staff users try to access another user's data they
             will get a 403 Error.
             If omitted, and the requesting user has staff access, then data for
             all enrolled users is returned. If the requesting user does not have

--- a/completion_aggregator/api/v1/views.py
+++ b/completion_aggregator/api/v1/views.py
@@ -258,7 +258,7 @@ class CompletionDetailView(CompletionViewMixin, APIView):
 
         username (optional):
             The username of the specified user for whom the course data is being
-            accessed. If a non-staff users try to access another user's data they
+            accessed. If non-staff users try to access another user's data they
             will get a 403 Error.
             If omitted, and the requesting user has staff access, then data for
             all enrolled users is returned. If the requesting user does not have

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -648,6 +648,24 @@ class CompletionViewTestCase(TestCase):
         response = self.client.get(self.get_list_url(version, username=test_user2.username))
         self.assertEqual(response.status_code, 403)
 
+    @ddt.data(0, 1)
+    @XBlock.register_temp_plugin(StubCourse, 'course')
+    @XBlock.register_temp_plugin(StubSequential, 'sequential')
+    @XBlock.register_temp_plugin(StubHTML, 'html')
+    def test_no_staff_access_no_user(self, version):
+        self.client.force_authenticate(self.test_user)
+        response = self.client.get(self.get_list_url(version))
+        self.assertEqual(response.status_code, 403)
+
+    @ddt.data(0, 1)
+    @XBlock.register_temp_plugin(StubCourse, 'course')
+    @XBlock.register_temp_plugin(StubSequential, 'sequential')
+    @XBlock.register_temp_plugin(StubHTML, 'html')
+    def test_staff_access_no_user(self, version):
+        self.client.force_authenticate(self.staff_user)
+        response = self.client.get(self.get_list_url(version))
+        self.assertEqual(response.status_code, 200)
+
     def get_detail_url(self, version, course_key, **params):
         """
         Given a course_key and a number of key-value pairs as keyword arguments,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -197,7 +197,7 @@ class CompletionViewTestCase(TestCase):
         """
         Ensures that the expected data is returned from the versioned list view.
         """
-        response = self.client.get(self.list_url.format(version), params={'username': self.test_user.username})
+        response = self.client.get(self.get_list_url(version, username=self.test_user.username))
         self.assertEqual(response.status_code, 200)
         expected = {
             'count': 1,
@@ -257,7 +257,7 @@ class CompletionViewTestCase(TestCase):
             user=self.test_user,
             course_id=self.other_org_course_key,
         )
-        response = self.client.get(self.list_url.format(version))
+        response = self.client.get(self.get_list_url(version, username=self.test_user.username))
         self.assertEqual(response.status_code, 200)
         expected = {
             'count': 2,
@@ -291,7 +291,9 @@ class CompletionViewTestCase(TestCase):
     @XBlock.register_temp_plugin(StubSequential, 'sequential')
     @XBlock.register_temp_plugin(StubHTML, 'html')
     def test_list_view_with_sequentials(self, version):
-        response = self.client.get(self.get_list_url(version, requested_fields='sequential'))
+        response = self.client.get(self.get_list_url(version,
+                                                     username=self.test_user.username,
+                                                     requested_fields='sequential'))
         self.assertEqual(response.status_code, 200)
         expected = {
             'count': 1,
@@ -322,7 +324,9 @@ class CompletionViewTestCase(TestCase):
         """
         Ensures that the expected data is returned from the versioned detail view.
         """
-        response = self.client.get(self.get_detail_url(version, six.text_type(self.course_key)))
+        response = self.client.get(self.get_detail_url(version,
+                                                       six.text_type(self.course_key),
+                                                       username=self.test_user.username))
         self.assertEqual(response.status_code, 200)
         expected_values = {
             'course_key': 'edX/toy/2012_Fall',
@@ -376,7 +380,7 @@ class CompletionViewTestCase(TestCase):
         # Now, try with a valid token header:
         token = _create_oauth2_token(self.test_user)
         response = self.client.get(
-            self.get_detail_url(version, self.course_key),
+            self.get_detail_url(version, self.course_key, username=self.test_user.username),
             HTTP_AUTHORIZATION="Bearer {0}".format(token)
         )
         self.assertEqual(response.status_code, 200)
@@ -410,7 +414,7 @@ class CompletionViewTestCase(TestCase):
     def test_detail_view_inactive_enrollment(self, version):
         self.test_enrollment.is_active = False
         self.test_enrollment.save()
-        response = self.client.get(self.get_detail_url(version, self.course_key))
+        response = self.client.get(self.get_detail_url(version, self.course_key, username=self.test_user.username))
         self.assertEqual(response.status_code, 404)
 
     @ddt.data(0, 1)
@@ -426,7 +430,9 @@ class CompletionViewTestCase(TestCase):
             user=self.test_user,
             course_id=self.other_org_course_key,
         )
-        response = self.client.get(self.get_detail_url(version, self.other_org_course_key))
+        response = self.client.get(self.get_detail_url(version,
+                                                       self.other_org_course_key,
+                                                       username=self.test_user.username))
         self.assertEqual(response.status_code, 200)
         expected_values = {
             'course_key': 'otherOrg/toy/2012_Fall',
@@ -440,7 +446,11 @@ class CompletionViewTestCase(TestCase):
     @XBlock.register_temp_plugin(StubSequential, 'sequential')
     @XBlock.register_temp_plugin(StubHTML, 'html')
     def test_detail_view_with_sequentials(self, version):
-        response = self.client.get(self.get_detail_url(version, self.course_key, requested_fields='sequential'))
+        response = self.client.get(self.get_detail_url(version,
+                                                       self.course_key,
+                                                       username=self.test_user.username,
+                                                       requested_fields='sequential')
+                                   )
         self.assertEqual(response.status_code, 200)
         expected_values = {
             'course_key': 'edX/toy/2012_Fall',
@@ -543,7 +553,12 @@ class CompletionViewTestCase(TestCase):
     @XBlock.register_temp_plugin(StubHTML, 'html')
     def test_invalid_optional_fields(self, version):
         response = self.client.get(
-            self.detail_url_fmt.format(version, 'edX/toy/2012_Fall') + '?requested_fields=INVALID'
+            self.get_detail_url(
+                version,
+                'edX/toy/2012_Fall',
+                username=self.test_user.username,
+                requested_fields="INVALID"
+            )
         )
         self.assertEqual(response.status_code, 400)
 
@@ -574,7 +589,7 @@ class CompletionViewTestCase(TestCase):
         user = User.objects.create(username='wrong')
         self.client.force_authenticate(user)
         response = self.client.get(self.get_list_url(version, username=self.test_user.username))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
     @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
@@ -604,6 +619,34 @@ class CompletionViewTestCase(TestCase):
         self.client.force_authenticate(self.staff_user)
         response = self.client.get(self.get_list_url(version, username='who-dat'))
         self.assertEqual(response.status_code, 404)
+
+    @ddt.data(0, 1)
+    @XBlock.register_temp_plugin(StubCourse, 'course')
+    @XBlock.register_temp_plugin(StubSequential, 'sequential')
+    @XBlock.register_temp_plugin(StubHTML, 'html')
+    def test_no_staff_access_other_user_detail(self, version):
+        self.client.force_authenticate(self.test_user)
+        test_user2 = User.objects.create(username='test_user2')
+        self.create_enrollment(
+            user=test_user2,
+            course_id=self.course_key,
+        )
+        response = self.client.get(self.get_detail_url(version, self.course_key, username=test_user2.username))
+        self.assertEqual(response.status_code, 403)
+
+    @ddt.data(0, 1)
+    @XBlock.register_temp_plugin(StubCourse, 'course')
+    @XBlock.register_temp_plugin(StubSequential, 'sequential')
+    @XBlock.register_temp_plugin(StubHTML, 'html')
+    def test_no_staff_access_other_user(self, version):
+        self.client.force_authenticate(self.test_user)
+        test_user2 = User.objects.create(username='test_user2')
+        self.create_enrollment(
+            user=test_user2,
+            course_id=self.course_key,
+        )
+        response = self.client.get(self.get_list_url(version, username=test_user2.username))
+        self.assertEqual(response.status_code, 403)
 
     def get_detail_url(self, version, course_key, **params):
         """


### PR DESCRIPTION
**Description:** Changed the behavior to give a 403 error when a non-staff users tries to request data about all/another user. Updated the tests to reflect this change. 

**JIRA:** https://tasks.opencraft.com/browse/BB-370

**Dependencies:** -
**Merge deadline:** -
**Installation instructions:** -

**Testing instructions:**

Use something like postman to call the API.

**Reviewers:**
- None selected yet

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**  Do we need to add a Changelog for this?
