### PR TITLE
Aggregate recent StaleCompletions first.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.4'
+__version__ = '1.5.5'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/aggregator.py
+++ b/completion_aggregator/aggregator.py
@@ -65,10 +65,10 @@ def perform_aggregation(batch_size=10000, delay=0.0, limit=None, routing_key=Non
     stale_blocks = collections.defaultdict(set)
     forced_updates = set()
     enqueued = 0
-    for idx in six.moves.range(min_id, max_id + 1, batch_size):
-        if enqueued > limit:
+    for idx in six.moves.range(max_id, min([min_id + batch_size, max_id]) - 1, -1 * batch_size):
+        if enqueued >= limit:
             break
-        evaluated = stale_queryset.filter(id__gte=idx, id__lt=idx + batch_size)
+        evaluated = stale_queryset.filter(id__gt=idx - batch_size, id__lte=idx)
         enqueued += len(evaluated)
         for stale in evaluated:
             enrollment = EnrollmentTuple(

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "Django>=1.8,<1.12",
         "django-model-utils>=2.0",
         "djangorestframework",
-        "XBlock",
+        "XBlock>=1.2.2",
         "celery>=3.1",
         "edx-celeryutils>=0.1.5",
         "edx-completion>=0.1.5",


### PR DESCRIPTION
**Description:** Current behavior is to aggregate oldest stale completions first, but this means we have to wait a long time before seeing the most recent activity, while getting historical data right away.  That could delay testing.

**JIRA:** YONK-1089

**Dependencies:** N/A

**Merge deadline:** ASAP.

**Installation instructions:** N/A

**Testing instructions:**

1.  Install this branch of openedx-completion-aggregator into any version of edx-platform (solutions is ideal, but it works on 
2.  Create a number of BlockCompletions, more than 5, in two different courses, by browsing through several pages of the courses.  
    Ways to complete blocks:
    * Spend at least five seconds on each page, scroll all the way to the bottom of the page.
    * Watch the last 5-10 seconds of a video.
    * Submit answers to problems.
3.  Run `./manage.py run_aggregator_service --limit=5 --batch-size=5`
4.  Verify that the more recently updated course was aggregated, but the older one was not, either by checking in /admin/completion_aggregator/aggregator/ or by sending an api request to /api/completion-aggregator/v1/course/course-v1:.../?requested_fields=chapter,sequential,vertical&username=<yourusername>


**Reviewers:**
- [x] @kaizoku 
FYI: @bradenmacdonald 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** 