### PR TITLE
MCKIN-8690: Allow non-staff queries without explicit username in v0 api.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.7'
+__version__ = '1.5.8'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/api/v0/views.py
+++ b/completion_aggregator/api/v0/views.py
@@ -159,6 +159,9 @@ class CompletionListView(CompletionViewMixin, APIView):
         """
         Handler for GET requests.
         """
+        if 'username' not in request.query_params and not request.user.is_staff:
+            self._effective_user = request.user
+
         paginator = self.pagination_class()  # pylint: disable=not-callable
         mobile_only = (self.request.query_params.get('mobile_only', 'false')).lower() == 'true'
 
@@ -318,6 +321,9 @@ class CompletionDetailView(CompletionViewMixin, APIView):
         """
         Handler for GET requests.
         """
+        if 'username' not in request.query_params and not request.user.is_staff:
+            self._effective_user = request.user
+
         course_key = CourseKey.from_string(course_key)
 
         # Return 404 if user does not have an active enrollment in the requested course

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -655,7 +655,7 @@ class CompletionViewTestCase(TestCase):
     def test_no_staff_access_no_user(self, version):
         self.client.force_authenticate(self.test_user)
         response = self.client.get(self.get_list_url(version))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 403 if version == 1 else 200)
 
     @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')


### PR DESCRIPTION
**Description:** We recently added the requirement to specify a username for non-staff users requesting their own information.  This breaks existing mobile apps using the v0 api.  Here we revert the behavior for the v0 api, but maintain it for v1.

**JIRA:** https://edx-wiki.atlassian.net/browse/MCKIN-8690

**Dependencies:** N/A 

**Merge deadline:** N/A

**Installation instructions:** 

**Testing instructions:**  Verify that accessing v0 completion apis without specifying a username returns data for the logged in user, if non-staff.

**Reviewers:**
- [ ] TBD

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** None.
