### PR TITLE
Make migration resilient to having an empty table.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.10'
+__version__ = '1.5.11'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** Make the stalecompletion index migration succeed if it encounters an empty table.  If a previous migration failed partway through, completion_aggregator_stalecompletionnew might exist, so delete that if it does.

**JIRA:** BB-85.

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** ASAP

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Have an empty table.
2. Manually create a completion_aggregator_stalecompletionnew table if it doesn't exist.
3. Run the migration.
4. Verify that the migration succeeds.  Verify that the table has indexes added to it.

**Reviewers:**
- [ ] @xitij2000  

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
