### PR TITLE
MCKIN-8766: Restore the missing block-update endpoint to the v0 api.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.11'
+__version__ = '1.5.12'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/api/v0/urls.py
+++ b/completion_aggregator/api/v0/urls.py
@@ -9,6 +9,11 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^course/$', views.CompletionListView.as_view()),
-    url(r'^course/(?P<course_key>.+)/$', views.CompletionDetailView.as_view()),
+    url(
+        r'^course/(?P<course_key>.+)/blocks/(?P<block_key>.+)/$',
+        views.CompletionBlockUpdateView.as_view(),
+        name='blockcompletion-update'
+    ),
+    url(r'^course/$', views.CompletionListView.as_view(), name='aggregator-list'),
+    url(r'^course/(?P<course_key>.+)/$', views.CompletionDetailView.as_view(), name='aggregator-detail'),
 ]

--- a/completion_aggregator/compat.py
+++ b/completion_aggregator/compat.py
@@ -143,11 +143,3 @@ def get_mobile_only_courses(enrollments):
     course_overview_list = CourseOverview.objects.filter(id__in=course_keys, mobile_available=True)
     filtered_course_overview = [overview.id for overview in course_overview_list]
     return enrollments.filter(course_id__in=filtered_course_overview)
-
-
-def get_course(course_key):
-    """
-    Get course for given key.
-    """
-    from courseware.courses import _get_course  # pylint: disable=import-error
-    return _get_course(course_key)

--- a/test_utils/test_app/models.py
+++ b/test_utils/test_app/models.py
@@ -16,3 +16,10 @@ class CourseEnrollment(models.Model):
     is_active = models.BooleanField(default=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
     course_id = CourseKeyField(max_length=255)
+
+    @classmethod
+    def is_enrolled(cls, user, course_id):
+        """
+        Return True if the specified enrollment exists.
+        """
+        return cls.objects.filter(is_active=True, user=user, course_id=course_id).exists()


### PR DESCRIPTION
**Description:** This endpoint existed on the old version of the v0 api, and somehow didn't get ported to the new, blockcompletion based v0.  This ticket updates that, and fixes a major blocker for deploying completion.

**JIRA:** MCKIN-8766, BB-493

**Dependencies:** N/A

**Merge deadline:** ASAP.

**Installation instructions:** 

**Testing instructions:**

As an authenticated user, submit a post to the specified endpoint with a valid course key and block key in that course, and a body of 
```json
{"completion": 1.0}
```

Verify that a BlockCompletion object gets created for the logged-in user.

**Reviewers:**
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** N/A
