### PR TITLE
BB-524: Handle stale completions for unknown users.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ docs: ## generate Sphinx HTML documentation, including API docs
 
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q pip-tools
-	pip-compile --upgrade -o requirements/dev.txt requirements/base.in requirements/dev.in requirements/quality.in
-	pip-compile --upgrade -o requirements/doc.txt requirements/base.in requirements/doc.in
-	pip-compile --upgrade -o requirements/quality.txt requirements/quality.in
-	pip-compile --upgrade -o requirements/test.txt requirements/base.in requirements/test.in
-	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
+	pip-compile --upgrade --no-index -o requirements/dev.txt requirements/base.in requirements/dev.in requirements/quality.in
+	pip-compile --upgrade --no-index -o requirements/doc.txt requirements/base.in requirements/doc.in
+	pip-compile --upgrade --no-index -o requirements/quality.txt requirements/quality.in
+	pip-compile --upgrade --no-index -o requirements/test.txt requirements/base.in requirements/test.in
+	pip-compile --upgrade --no-index -o requirements/travis.txt requirements/travis.in
 	# Let tox control the Django version for tests
 	sed '/^django==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt

--- a/completion_aggregator/api/v0/urls.py
+++ b/completion_aggregator/api/v0/urls.py
@@ -8,6 +8,8 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = 'completion_aggregator'
+
 urlpatterns = [
     url(
         r'^course/(?P<course_key>.+)/blocks/(?P<block_key>.+)/$',

--- a/completion_aggregator/api/v1/urls.py
+++ b/completion_aggregator/api/v1/urls.py
@@ -8,6 +8,8 @@ from django.conf.urls import url
 
 from . import views
 
+app_name = 'completion_aggregator'
+
 urlpatterns = [
     url(r'^course/$', views.CompletionListView.as_view()),
     url(r'^course/(?P<course_key>.+)/$', views.CompletionDetailView.as_view()),

--- a/completion_aggregator/models.py
+++ b/completion_aggregator/models.py
@@ -74,23 +74,21 @@ class AggregatorManager(models.Manager):
         """
         if not isinstance(user, User):
             raise TypeError(
-                _("user must be an instance of `django.contrib.auth.models.User`.  Got {}".format(
+                _("user must be an instance of `django.contrib.auth.models.User`.  Got {}").format(
                     type(user)
-                ))
+                )
             )
         if not isinstance(course_key, CourseKey):
             raise TypeError(
-                _(
-                    "course_key must be an instance of `opaque_keys.edx.keys.CourseKey`.  Got {}".format(
-                        type(course_key)
-                    ))
+                _("course_key must be an instance of `opaque_keys.edx.keys.CourseKey`.  Got {}").format(
+                    type(course_key)
+                )
             )
         if not isinstance(block_key, UsageKey):
             raise TypeError(
-                _(
-                    "block_key must be an instance of `opaque_keys.edx.keys.UsageKey`.  Got {}".format(
-                        type(block_key)
-                    ))
+                _("block_key must be an instance of `opaque_keys.edx.keys.UsageKey`.  Got {}").format(
+                    type(block_key)
+                )
             )
 
     @staticmethod

--- a/completion_aggregator/tasks/aggregation_tasks.py
+++ b/completion_aggregator/tasks/aggregation_tasks.py
@@ -82,7 +82,13 @@ def update_aggregators(username, course_key, block_keys=(), force=False):
     optimizations in how aggregators are recalculated.
 
     """
-    user = User.objects.get(username=username)
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        log.warning("User %s does not exist.  Marking stale completions resolved.", username)
+        StaleCompletion.objects.filter(username=username).update(resolved=True)
+        return
+
     course_key = CourseKey.from_string(course_key)
     block_keys = set(UsageKey.from_string(key).map_into_course(course_key) for key in block_keys)
     log.info("Updating aggregators in %s for %s. Changed blocks: %s", course_key, user.username, block_keys)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -26,6 +26,7 @@ class SignalsTestCase(TestCase):
     is saved
     """
     def setUp(self):
+        super(SignalsTestCase, self).setUp()
         user_model = get_user_model()
         self.user = user_model.objects.create()
         self.extra_users = [

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,7 +17,6 @@ from rest_framework.test import APIClient
 from xblock.core import XBlock
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import timezone
 
@@ -27,6 +26,12 @@ from completion_aggregator.api.v1.views import CompletionViewMixin
 from completion_aggregator.tasks.aggregation_tasks import AggregationUpdater
 from test_utils.compat import StubCompat
 from test_utils.test_blocks import StubCourse, StubHTML, StubSequential
+
+try:
+    from django.urls import reverse
+except ImportError:  # Django 1.8 compatibility
+    from django.core.urlresolvers import reverse
+
 
 empty_compat = StubCompat([])
 
@@ -129,6 +134,7 @@ class CompletionViewTestCase(CompletionAPITestMixin, TestCase):
     detail_url_fmt = '/v{}/course/{}/'
 
     def setUp(self):
+        super(CompletionViewTestCase, self).setUp()
         self.test_user = User.objects.create(username='test_user')
         self.staff_user = User.objects.create(username='staff', is_staff=True)
         self.test_enrollment = self.create_enrollment(
@@ -749,7 +755,7 @@ class CompletionBlockUpdateViewTestCase(CompletionAPITestMixin, TestCase):
     usage_key = course_key.make_usage_key('html', 'course-sequence1-html1')
 
     def setUp(self):
-
+        super(CompletionBlockUpdateViewTestCase, self).setUp()
         self.test_user = User.objects.create(username='test_user')
         self.staff_user = User.objects.create(username='staff', is_staff=True)
         self.test_enrollment = self.create_enrollment(


### PR DESCRIPTION
**Description:** 

When updating aggregators, sometimes a StaleCompletion exists for a User that doesn't exist (probably from old data or test data that sneaked in).  Those cause harmless errors, but the errors mean that the StaleCompletion doesn't get resolved, so the same errors occur every hour.  This PR resolves the StaleCompletions.

**JIRA:** [BB-524](https://tasks.opencraft.com/browse/BB-524)

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** None

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Create a stale completion for a non-existent user.
2. Run `./manage.py run_aggregator_service`
3. Verify that the StaleCompletion is marked resolved, and that no exceptions are raised.

Note, this goes through a celery task so make sure CELERY_ALWAYS_EAGER is enabled, or that workers are running.

**Reviewers:**
- [ ] TBD

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** I also included some general bookkeeping and cleanup into this PR, but kept them in a separate commit.  It may be easier to review this PR one commit at a time.
