### PR TITLE
Add root_block option to only get a subtree of aggregators

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.12'
+__version__ = '1.5.13'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/management/commands/reaggregate_course.py
+++ b/completion_aggregator/management/commands/reaggregate_course.py
@@ -1,0 +1,93 @@
+"""
+run_aggregator_service management command.
+
+Usage:
+
+    ./manage.py run_aggregator_service
+
+Performs the actual aggregation.
+
+For continuous aggregation, set a cron job to run this task periodically.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+
+from django.core.management.base import BaseCommand
+
+from completion.models import BlockCompletion
+
+from ... import compat
+from ...models import StaleCompletion
+
+
+class Command(BaseCommand):
+    """
+    run_aggregator_service management command.
+    """
+
+    def add_arguments(self, parser):
+        """
+        Add command-line arguments
+        """
+        parser.add_argument(
+            '-a', '--all',
+            help='Reaggregate all courses',
+            action='store_true',
+        )
+        parser.add_argument(
+            'course_keys',
+            help='CourseKeys of courses that need reaggregation',
+            nargs='*',
+        )
+        parser.add_argument(
+            '--routing-key',
+            dest='routing_key',
+            help='Celery routing key to use.',
+        )
+
+    def handle(self, *args, **options):
+        """
+        Run the aggregator service.
+        """
+
+        self.set_logging(options['verbosity'])
+
+        if options['all']:
+            options['course_keys'] = BlockCompletion.objects.values_list('course_key').distinct()
+        CourseEnrollment = compat.course_enrollment_model()  # pylint: disable=invalid-name
+        for course in options['course_keys']:
+            all_enrollments = CourseEnrollment.objects.filter(course_key=course).select_related('user')
+            StaleCompletion.objects.bulk_create(
+                (
+                    StaleCompletion(
+                        course_key=enrollment.course_id,
+                        username=enrollment.user,
+                        block_key=None,
+                        force=True,
+                        resolved=False
+                    )
+                    for enrollment in all_enrollments
+                ),
+                batch_size=10000,
+            )
+
+        return
+
+    def set_logging(self, verbosity):
+        """
+        Set the logging level depending on the desired vebosity
+        """
+        handler = logging.StreamHandler()
+        root_logger = logging.getLogger('')
+        root_logger.addHandler(handler)
+        handler.setFormatter(logging.Formatter('%(levelname)s|%(message)s'))
+
+        if verbosity == 1:
+            logging.getLogger('completion_aggregator').setLevel(logging.WARNING)
+        elif verbosity == 2:
+            logging.getLogger('completion_aggregator').setLevel(logging.INFO)
+        elif verbosity == 3:
+            logging.getLogger().setLevel(logging.DEBUG)
+            handler.setFormatter(logging.Formatter('%(name)s|%(asctime)s|%(levelname)s|%(message)s'))

--- a/completion_aggregator/serializers.py
+++ b/completion_aggregator/serializers.py
@@ -96,7 +96,7 @@ class AggregatorAdapter(object):
     The adapter or list of adapters can then be passed to the serializer for processing.
     """
 
-    def __init__(self, user, course_key, aggregators=None, recalculate_stale=False):
+    def __init__(self, user, course_key, aggregators=None, root_block=None, recalculate_stale=False):
         """
         Initialize the adapter.
 
@@ -117,7 +117,7 @@ class AggregatorAdapter(object):
         else:
             is_stale = False
 
-        self.update_aggregators(aggregators or [], is_stale=is_stale)
+        self.update_aggregators(aggregators or [], root_block=root_block, is_stale=is_stale)
 
     def __getattr__(self, name):
         """
@@ -140,7 +140,7 @@ class AggregatorAdapter(object):
         if is_aggregation_name(aggregator.aggregation_name):
             self.aggregators[aggregator.aggregation_name].append(aggregator)
 
-    def update_aggregators(self, iterable, is_stale=False):
+    def update_aggregators(self, iterable, root_block=None, is_stale=False):
         """
         Add a number of Aggregators to the adapter.
 
@@ -151,8 +151,10 @@ class AggregatorAdapter(object):
             iterable = calculate_updated_aggregators(
                 self.user,
                 self.course_key,
+                root_block=root_block,
                 force=True,
             )
+
         for aggregator in iterable:
             self.add_aggregator(aggregator)
 

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -37,7 +37,10 @@ class StubCompat(object):
         Overridden here to prevent the default behavior, which relies on
         modulestore.
         """
-        return CompatCourseBlocks(*self.blocks)
+        root_segments = course_block_key.block_id.split('-')
+        return CompatCourseBlocks(
+            *(block for block in self.blocks if block.block_id.split('-')[:len(root_segments)] == root_segments)
+        )
 
     def get_affected_aggregators(self, course_blocks, changed_blocks):
         """


### PR DESCRIPTION

**Description:** Adds the ability to specify a block key to serve as the root of the requested aggregators.  If the view would calculate them on the fly, it instead only calculates the aggregators under (and including) the specified block.  

Some notes: 
* if it doesn't calculate the aggregators, it ignores the root_block parameter, and sends back all the data, because it would take more time to calculate which ones need to be returned than just to make the single indexed db query to get the blocks.  
* One point of ugliness is that the course-level aggregator gets returned as `0.0/None/0.0`  I don't see an easy way to resolve that, given the format of the response, but since the user only wanted a subtree anyway, we'll expect them not to use that data.

**JIRA:** https://tasks.opencraft.com/browse/BB-538

**Dependencies:** N/A

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:**

1. Visit an the aggregator detail page for a full-size course, specifying `?username=<yourusername>&requested_fields=chapter,sequential,vertical`
2. Verify that it returns all blocks for the course.  Check the response time in the browsers dev tools.
3. Add `&root_block=<a chapter block key>`.  
4. Verify that it returns fewer blocks, the course completion is empty `0.0/None/0.0`, and that performance improved.

**Reviewers:**
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
