### PR TITLE
Allow migrating specific coursemodulecompletions by id.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.13'
+__version__ = '1.5.14'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** 

Update the migrate_progress command with a few new enhancements:

* Add an option to copy CoureModuleCompletion objects by id.
* Migrate batches by id, rather than by offset.
* Add a `select_related` clause to prevent pulling user objects separately.


**JIRA:** MCKIN-8829

**Dependencies:** N/A

**Merge deadline:** ASAP

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

*    Using manage.py dbshell, Check that you have some entries in progress_coursemodulecompletions (CMC). Check a few id values.
*    Delete all your completion_blockcompletion records.
*    Run ./manage.py lms --settings=devstack migrate_progress --ids=1,4,5,10,8 with a few IDs that are present in your CMC table, and a few that are not.
*    Verify that corresponding records were created in the blockcompletion table.
*    Run ./manage.py lms --settings=devstack migrate_progress --start-index=5 --stop-index=100 --batch-size=5 with values for --start-index and --stop-index that are in the middle of the full range of CMC ids.
*    Verify from logging output that the task is run on batches of the appropriate size
*    Verify in the BlockCompletion table that all records were created.
*    Verify that StaleCompletions have been created. Duplicates are okay here.

**Reviewers:**
- [ ] @xitij2000 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
