### PR TITLE
[BB-533] Create test for specifying user_ids in API request

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -687,7 +687,7 @@ class CompletionViewTestCase(CompletionAPITestMixin, TestCase):
         )
 
         self.client.force_authenticate(self.staff_user)
-        user_ids = f'{some_user.id},{yet_another_user.id}'
+        user_ids = str(some_user.id) + str(yet_another_user.id)
         response = self.client.get(self.get_detail_url(version, self.course_key, user_ids=user_ids))
         self.assertEqual(response.status_code, 200)
         expected_values = [

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -702,7 +702,7 @@ class CompletionViewTestCase(CompletionAPITestMixin, TestCase):
                 'completion': self._get_expected_completion(1, earned=6.0, possible=12.0, percent=0.5),
             },
         ]
-        expected = self._get_expected_detail(version, expected_values)
+        expected = self._get_expected_detail(version, expected_values, count=2)
         self.assertEqual(response.data, expected)
 
     def _create_cohort(self, owner, users):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -632,15 +632,14 @@ class CompletionViewTestCase(CompletionAPITestMixin, TestCase):
         assert mock_update.call_count == 0
         assert models.StaleCompletion.objects.filter(resolved=False).count() == 2
 
-    @ddt.data(0, 1)
     @XBlock.register_temp_plugin(StubCourse, 'course')
     @XBlock.register_temp_plugin(StubSequential, 'sequential')
     @XBlock.register_temp_plugin(StubHTML, 'html')
-    def test_detail_view_staff_requested_multiple_users(self, version):
+    def test_detail_view_staff_requested_multiple_users(self):
         """
         Test that requesting course completions for a set of users filters out the other enrolled users
         """
-
+        version = 1
         some_user = User.objects.create(username='test_user_2')
         self.create_enrollment(
             user=some_user,
@@ -687,7 +686,7 @@ class CompletionViewTestCase(CompletionAPITestMixin, TestCase):
         )
 
         self.client.force_authenticate(self.staff_user)
-        user_ids = str(some_user.id) + "," + str(yet_another_user.id)
+        user_ids = "{},{}".format(some_user.id, yet_another_user.id)
         response = self.client.get(self.get_detail_url(version, self.course_key, user_ids=user_ids))
         self.assertEqual(response.status_code, 200)
         expected_values = [

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -687,8 +687,8 @@ class CompletionViewTestCase(CompletionAPITestMixin, TestCase):
         )
 
         self.client.force_authenticate(self.staff_user)
-        response = self.client.get(
-            self.get_detail_url(version, self.course_key, user_ids=f'{some_user.id},{yet_another_user.id}'))
+        user_ids = f'{some_user.id},{yet_another_user.id}'
+        response = self.client.get(self.get_detail_url(version, self.course_key, user_ids=user_ids))
         self.assertEqual(response.status_code, 200)
         expected_values = [
             {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -687,7 +687,7 @@ class CompletionViewTestCase(CompletionAPITestMixin, TestCase):
         )
 
         self.client.force_authenticate(self.staff_user)
-        user_ids = str(some_user.id) + str(yet_another_user.id)
+        user_ids = str(some_user.id) + "," + str(yet_another_user.id)
         response = self.client.get(self.get_detail_url(version, self.course_key, user_ids=user_ids))
         self.assertEqual(response.status_code, 200)
         expected_values = [

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -687,7 +687,8 @@ class CompletionViewTestCase(CompletionAPITestMixin, TestCase):
         )
 
         self.client.force_authenticate(self.staff_user)
-        response = self.client.get(self.get_detail_url(version, self.course_key, user_ids='test_user_2,test_user_4'))
+        response = self.client.get(
+            self.get_detail_url(version, self.course_key, user_ids=f'{some_user.id},{yet_another_user.id}'))
         self.assertEqual(response.status_code, 200)
         expected_values = [
             {


### PR DESCRIPTION
**Description:** Adds a test for specifying user_ids in API requests functionality

**JIRA:** https://tasks.opencraft.com/browse/BB-533

**Dependencies:** 

**Merge deadline:**

**Installation instructions:** 

**Testing instructions:**
Run the test at 
`openedx-completion-aggregator/tests/test_views.py::CompletionViewTestCase::test_detail_view_staff_requested_multiple_users`


**Reviewers:**
- [ ] @Agrendalath 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
I'm having troubles installing dependencies on Ubuntu 18.04 in order to run the tests. Needs to be confirmed working before merge.
