### PR TITLE
MCKIN-9202: Exclude unregistered block types from completion.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.18'
+__version__ = '1.5.19'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/core.py
+++ b/completion_aggregator/core.py
@@ -13,6 +13,7 @@ import pytz
 import six
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
+from xblock.plugin import PluginMissingError
 
 from django.utils import timezone
 
@@ -171,7 +172,11 @@ class AggregationUpdater(object):
 
         Dispatches to an appropriate method given the block's completion_mode.
         """
-        mode = XBlockCompletionMode.get_mode(XBlock.load_class(block.block_type))
+        try:
+            mode = XBlockCompletionMode.get_mode(XBlock.load_class(block.block_type))
+        except PluginMissingError:
+            # Do not count blocks that aren't registered
+            mode = XBlockCompletionMode.EXCLUDED
         if mode == XBlockCompletionMode.EXCLUDED:
             return self.update_for_excluded()
         elif mode == XBlockCompletionMode.COMPLETABLE:

--- a/completion_aggregator/management/commands/run_aggregator_service.py
+++ b/completion_aggregator/management/commands/run_aggregator_service.py
@@ -30,8 +30,8 @@ class Command(BaseCommand):
         """
         parser.add_argument(
             '--batch-size',
-            help='Maximum number of CourseModuleCompletions to migrate, per celery task. (default: 10000)',
-            default=10000,
+            help='Maximum number of StaleCompletions to process, per celery task. (default: 1000)',
+            default=1000,
             type=int,
         )
         parser.add_argument(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -210,6 +210,9 @@ class CalculateUpdatedAggregatorsTestCase(TestCase):
             self.course_key.make_usage_key('html', 'course-chapter1-block2'),
             self.course_key.make_usage_key('html', 'course-chapter2-block1'),
             self.course_key.make_usage_key('html', 'course-chapter2-block2'),
+            # image_explorer is an unregistered block type, and should be
+            # treated as EXCLUDED from aggregation.
+            self.course_key.make_usage_key('image_explorer', 'course-chapter2-badblock'),
             self.course_key.make_usage_key('chapter', 'course-zeropossible'),
         ]
         patch = mock.patch('completion_aggregator.core.compat', StubCompat(self.blocks))


### PR DESCRIPTION
**Description:** Previously, the hourly aggregation task was failing whenever it encountered a course with an invalid block type.  This happened with historical courses that had run when different blocks were available.  Apparently at some time in the past, `image-explorer` was called `image_explorer`, and now any courses that contain an `image_explorer` block fail to aggregate completions, and the `StaleCompletion` records never get cleared out.  As a result, it tries to aggregate the same course every hour, and our client sees a few otherwise harmless errors in their NewRelic reporting.

This change should allow some of those records to be cleared out, and silence the errors.

**JIRA:** MCKIN-9209, BB-759

**Dependencies:** N/A

**Merge deadline:** None

**Installation instructions:** 

On a solutions devstack, in the django admin, install this branch, then enable the waffle switch "completion.enable_completion_tracking".

**Testing instructions:**

1. Navigate through a few sections of a course, scrolling through each page, and reading the content.
2. Verify that completion_aggregator_stalecompletion records are created.
3. Rename one of the block types that is used in the course, by modifying `common/lib/xmodule/setup.py`: Under XMODULES, change (for example) `html = ...` to `htm = ...`.
4. Run `./manage.py lms --settings=devstack run_aggregator_service`.  Verify that values are added to the completion_aggregator_aggregator table, and that all entries in the completion_aggregator_stalecompletion table are marked "resolved."  The results will look off, because all of the "html" blocks are now invalid, but browsing the course on the site will likely be thoroughly broken anyway.  In the real use case, the now-invalid block type rarely shows up, and only in long-completed courses.

**Reviewers:**
- [ ] @giovannicimolin  

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
