### PR TITLE
YONK-1302: Reduce memory footprint of cache entries.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.19'
+__version__ = '1.5.20'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/cachegroup.py
+++ b/completion_aggregator/cachegroup.py
@@ -56,8 +56,14 @@ class CacheGroup(object):
     def touch(self, key, timeout):
         """
         Update the timeout for a given key in the cache.
+
+        Returns True if the cache key was updated.
+
+        This functionality is available in Django 2.1 and above.
         """
-        return cache.touch(key, timeout=timeout)
+        if hasattr(cache, 'touch'):
+            return cache.touch(key, timeout=timeout)
+        return False
 
     def delete(self, key):
         """

--- a/completion_aggregator/cachegroup.py
+++ b/completion_aggregator/cachegroup.py
@@ -53,6 +53,12 @@ class CacheGroup(object):
         cache_entry = _CacheGroupEntry(group, value, cached_at)
         return cache.set(key, cache_entry, timeout)
 
+    def touch(self, key, timeout):
+        """
+        Update the timeout for a given key in the cache.
+        """
+        return cache.touch(key, timeout=timeout)
+
     def delete(self, key):
         """
         Invalidate the entry in the cache.

--- a/completion_aggregator/compat.py
+++ b/completion_aggregator/compat.py
@@ -13,7 +13,8 @@ It can be stubbed out using:
 `StubCompat` is a class which implements all the below methods in a way that
 eliminates external dependencies
 """
-from __future__ import absolute_import, unicode_literals
+
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.conf import settings
 
@@ -54,7 +55,7 @@ def get_item_not_found_error():
     return ItemNotFoundError
 
 
-def init_course_blocks(user, course_block_key):
+def init_course_blocks(user, root_block_key):
     """
     Return a BlockStructure representing the course.
 
@@ -71,7 +72,7 @@ def init_course_blocks(user, course_block_key):
         get_course_block_access_transformers() + [AggregatorAnnotationTransformer()]
     )
 
-    return get_course_blocks(user, course_block_key, transformers)
+    return get_course_blocks(user, root_block_key, transformers)
 
 
 def get_block_completions(user, course_key):
@@ -112,24 +113,20 @@ def course_enrollment_model():
 
 def get_users_enrolled_in(course_key):
     """
-    Return list of users enrolled in supplied course_key.
+    Return a list of users enrolled in supplied course_key.
     """
     return course_enrollment_model().objects.users_enrolled_in(course_key)
 
 
-def get_affected_aggregators(course_blocks, changed_blocks):
+def get_block_aggregators(course_blocks, block):
     """
-    Return the set of aggregator blocks that may need updating.
+    Return a list of aggregator blocks that contain the specified block.
     """
-    affected_aggregators = set()
-    for block in changed_blocks:
-        block_aggregators = course_blocks.get_transformer_block_field(
-            block,
-            AggregatorAnnotationTransformer,
-            AggregatorAnnotationTransformer.AGGREGATORS
-        )
-        affected_aggregators.update(block_aggregators or [])
-    return affected_aggregators
+    return course_blocks.get_transformer_block_field(
+        block,
+        AggregatorAnnotationTransformer,
+        AggregatorAnnotationTransformer.AGGREGATORS
+    ) or []
 
 
 def get_mobile_only_courses(enrollments):

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -30,27 +30,23 @@ class StubCompat(object):
         """
         return course_key.make_usage_key('course', 'course')
 
-    def init_course_blocks(self, user, course_block_key):  # pylint: disable=unused-argument
+    def init_course_blocks(self, user, root_block_key):  # pylint: disable=unused-argument
         """
         Not actually used in this implementation.
 
         Overridden here to prevent the default behavior, which relies on
         modulestore.
         """
-        root_segments = course_block_key.block_id.split('-')
+        root_segments = root_block_key.block_id.split('-')
         return CompatCourseBlocks(
             *(block for block in self.blocks if block.block_id.split('-')[:len(root_segments)] == root_segments)
         )
 
-    def get_affected_aggregators(self, course_blocks, changed_blocks):
+    def get_block_aggregators(self, course_blocks, block):
         """
-        Get all the aggregator blocks affected by a change to one of the given blocks.
+        Returns a list of aggregator blocks that contain the specified block.
         """
-        affected = set()
-        for block in course_blocks.blocks:
-            if any(changed.block_id.startswith('{}-'.format(block.block_id)) for changed in changed_blocks):
-                affected.add(block)
-        return affected
+        return [agg for agg in course_blocks.blocks if block.block_id.startswith('{}-'.format(agg))]
 
     def get_block_completions(self, user, course_key):
         """

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -5,6 +5,8 @@ Test the aggregator functions directly.
 # Redefined outer names are explicitly used by pytest fixtures.
 # pylint: disable=redefined-outer-name
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 import six
 from mock import patch

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -423,14 +423,13 @@ class PartialUpdateTest(TestCase):
                 - auth_user (fetch user details)
                 - completion_aggregator_aggregator (user specific for specific course)
                 - completion_blockcompletion (user specific)
-                - completion_aggregator_aggregator (user specific for specific course and block)
             * Insert or Update Query
                 - completion_aggregator_aggregator (insert aggregation data)
             * Update query
                 - completion_aggregator_stalecompletion (user specific)
         '''   # pylint: disable=pointless-string-statement
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             aggregation_tasks.update_aggregators(self.user.username, six.text_type(self.course_key), {
                 six.text_type(completion.block_key)})
 
@@ -449,7 +448,7 @@ class PartialUpdateTest(TestCase):
             ),
         ]
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             aggregation_tasks.update_aggregators(
                 username=self.user.username,
                 course_key=six.text_type(self.course_key),


### PR DESCRIPTION
**Description:** Reduce memory footprint of cache entries.

We do this by extracting only the information we need from the BlockStructure
object and storing it in simple data structures.

Also included:

* Removing redundant db queries.
* Only setting cache values when new values have been calculated (otherwise, just bump the timeout)

**JIRA:** YONK-1302, [BB-820](https://tasks.opencraft.com/browse/BB-820)

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** ASAP

**Installation instructions:** 

**Testing instructions:**

This is a performance refactor.  Verify that views that depend on completions still get accurate results, and that the size of cache entries is reduced by this operation.  

After visiting course pages in apros, check the size of the cached data.  To get the size of a cache entry, as stored in memcache, you need to first get the cache key, as follows:

```python
from util.memcache import safe_key

key = safe_key(
    'completion_aggregator.updater.{user_id}-{course_key}-{block_key}'.format(
        user_id=user_id, 
        course_key=course_key, 
        block_key=block_key or "COURSE", # Use "COURSE" to get the tree for the whole course.
    ),
    version=1,
    prefix='default',
)
```

Then use it to make a raw query to memcached, and check the size of the returned bytes.

```python
import socket
sock = socket.socket()
sock.connect(('localhost', 11211))
sock.send('get {}\n'.format(key))
response = sock.recv(2**30) # Get all the bytes.  If you think you didn't get all the bytes, try response += sock.recv(2**30) until the call blocks.
print(len(response))
```
The size of the response running this script against this branch should be multiple times smaller than running it against the master branch.

To clear the cache between runs do:

```python
from django.core.cache import cache
cache.clear()
```

**Reviewers:**
- [ ] @xitij2000 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author notes/concerns:** 

* On the course I tested, the size of the memcache entry for a whole course was reduced from 500kb to 125kb, so 4x improvement.  Results over all courses in production may vary.
* The memory usage is better, I don't have a good sense of whether the improvement is sufficient, and no way to test it without seeing it in production.
* I'm also making an assumption that the cache entry size is the bottleneck.  Each call to the completion endpoint is only making a single call to set the cache value, so I think it's a reasonable assumption.
* I also spotted an excess database query which may be causing slowness.  See inline comment.
* The caching is here to deal with slowness in getting the course block structure in the first place.  If we can speed that up by not fetching student_view_data, caching may become unnecessary, but there is still an outstanding question of whether that will affect the correctness of results (if the structure of the course can ever depend on the content in student_view_data, perhaps for adaptive learning).
