### PR TITLE
BB-941: Handle missing block keys gracefully.

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.20'
+__version__ = '1.5.21'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/core.py
+++ b/completion_aggregator/core.py
@@ -183,6 +183,9 @@ class AggregationUpdater(object):
         if changed_blocks:
             affected_aggregators = set()
             for block in changed_blocks:
+                if block not in self.course_blocks:
+                    # The course structure has changed.  Conservatively recalculate the whole tree.
+                    return BagOfHolding()
                 affected_aggregators.update(self.course_blocks[block].aggregators)
             return affected_aggregators
         else:

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -46,7 +46,8 @@ class StubCompat(object):
         """
         Returns a list of aggregator blocks that contain the specified block.
         """
-        return [agg for agg in course_blocks.blocks if block.block_id.startswith('{}-'.format(agg))]
+
+        return [agg for agg in course_blocks.blocks if block.block_id.startswith('{}-'.format(agg.block_id))]
 
     def get_block_completions(self, user, course_key):
         """


### PR DESCRIPTION
We recalculate the entire course when they are found, so we know that
our aggregators reflect the current structure of the course.  This
should be a relatively rare occurrence.

This PR also fixes an issue where block aggregators were not being found
in the test compat library.  This made every test run act as though all
aggregators had been changed.

Finally, we add a test to cover the case where a block has been
completed but the block key is not included in the list of
changed_blocks, and so the aggregator is not updated.  A later run of the
aggregator will catch the new change.

**JIRA:** BB-941 - Need to find or create a MCKIN/YONK ticket.

**Dependencies:** N/A 

**Merge deadline:** None

**Installation instructions:** 

**Testing instructions:**

See new test cases.  Manual testing would involve creating a stale completion that refers to a block that is valid, but doesn't exist in the course, and then running aggregators.  Under the old code, it should raise an exception, and not mark the StaleCompletion as resolved.  Under the new code, it should recalculate the course aggregators, and resolve the StaleCompletion.

**Reviewers:**
- [x] @xitij2000  

**Merge checklist:**
- [x] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** None.
