### PR TITLE
MCKIN-10256: Resolve stale completions that contain a course_key to a nonexistent course

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.21'
+__version__ = '1.5.22'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/batch.py
+++ b/completion_aggregator/batch.py
@@ -75,7 +75,7 @@ def perform_aggregation(batch_size=10000, delay=0.0, limit=None, routing_key=Non
                 username=stale.username,
                 course_key=stale.course_key,
             )
-            if stale.block_key is None:
+            if not stale.block_key:
                 stale_blocks[enrollment] = utils.BagOfHolding()
             blocks = stale_blocks[enrollment]
             if isinstance(blocks, utils.BagOfHolding) or len(blocks) <= MAX_KEYS_PER_TASK:

--- a/completion_aggregator/core.py
+++ b/completion_aggregator/core.py
@@ -369,8 +369,10 @@ def update_aggregators(user, course_key, block_keys=frozenset(), force=False):
     try:
         updater = AggregationUpdater(user, course_key, compat.get_modulestore())
     except compat.get_item_not_found_error():
-        log.exception("Course not found in modulestore.  Skipping aggregation for %s/%s.", user, course_key)
+        log.exception("Course not found in modulestore.  Skipping aggregation for %s in %s.", user, course_key)
+        StaleCompletion.objects.filter(username=user.username, course_key=course_key).update(resolved=True)
     except TypeError:
-        log.exception("Could not parse modulestore data.  Skipping aggregation for %s/%s.", user, course_key)
+        log.exception("Could not parse modulestore data.  Skipping aggregation for %s in %s.", user, course_key)
+        StaleCompletion.objects.filter(username=user.username, course_key=course_key).update(resolved=True)
     else:
         updater.update(block_keys, force)

--- a/test_utils/compat.py
+++ b/test_utils/compat.py
@@ -28,7 +28,10 @@ class StubCompat(object):
 
         For the purposes of testing, we're just going by convention.
         """
-        return course_key.make_usage_key('course', 'course')
+        if course_key in {block.course_key for block in self.blocks}:
+            return course_key.make_usage_key('course', 'course')
+        else:
+            raise self.get_item_not_found_error()
 
     def init_course_blocks(self, user, root_block_key):  # pylint: disable=unused-argument
         """

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -174,9 +174,12 @@ class StaleCompletionResolutionTestCase(TestCase):
     @XBlock.register_temp_plugin(HTMLBlock, 'html')
     @pytest.mark.django_db
     def test_stale_completion_resolution(self):
+        # Verify that all stale completions get resolved, even if the course
+        # is not present in the modulestore
         course_key = CourseKey.from_string('course-v1:OpenCraft+Onboarding+2018')
         for user in self.users:
-            StaleCompletion.objects.create(username=user.username, course_key=course_key, block_key=None, force=True)
+            StaleCompletion.objects.create(username=user.username, course_key=course_key, block_key='', force=False)
+            StaleCompletion.objects.create(username=user.username, course_key='not/a/course', block_key='', force=False)
         assert not StaleCompletion.objects.filter(resolved=True).exists()
         assert StaleCompletion.objects.filter(resolved=False).exists()
         with compat_patch(course_key):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -19,7 +19,9 @@ from completion_aggregator.core import AggregationUpdater
 from test_utils.compat import StubCompat
 from test_utils.test_blocks import StubCourse, StubSequential
 
-empty_compat = StubCompat([])
+stub_compat = StubCompat([
+    CourseKey.from_string('course-v1:abc+def+ghi').make_usage_key('course', 'course'),
+])
 
 
 class AggregatorAdapterTestCase(TestCase):
@@ -72,8 +74,8 @@ def _course_completion_serializer_factory(serializer_cls_args):
 
 
 @ddt.ddt
-@patch('completion_aggregator.serializers.compat', empty_compat)
-@patch('completion_aggregator.core.compat', empty_compat)
+@patch('completion_aggregator.serializers.compat', stub_compat)
+@patch('completion_aggregator.core.compat', stub_compat)
 class CourseCompletionSerializerTestCase(TestCase):
     """
     Test that the CourseCompletionSerializer returns appropriate results.


### PR DESCRIPTION
**Description:** There are a large number of StaleCompletions on stage that are not getting resolved properly.  They all seem to be for non existent courses, and all have a block_key of `''`.  Make sure those conditions are accounted for when resolving completions.

**JIRA:** [MCKIN-10256](https://edx-wiki.atlassian.net/browse/MCKIN-10256)

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** N/A

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

See newly added unit tests.  

1. Create a stale completion with a course_key of `'non/existent/block'` and a block_key of `''`.  
2. On the main branch, run ./manage.py lms --settings=devstack run_aggregator_service, and confirm that the block is not resolved.
3. On the PR branch, run ./manage.py lms --settings=devstack run_aggregator_service, and confirm that the block is resolved.

**Reviewers:**
- [ ] @xitij2000 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
