### PR TITLE
YONK-1515 Updated edx-completion max version to 2.0.0

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '1.5.23'
+__version__ = '1.5.24'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "XBlock>=1.2.2",
         "celery>=3.1",
         "edx-celeryutils>=0.1.5",
-        "edx-completion>=1.0.3,<2",
+        "edx-completion>=1.0.3,<=2.0.0",
         "edx-opaque-keys",
     ],
     license="AGPL 3.0",


### PR DESCRIPTION
**Description:**
We are currently using openedx-completion-aggregator==1.5.23 fro ginkgo release and this version is deployed on prod. This version of openedx-completion-aggregator is using edx-completion==1.0.3 but ironwood release of edx-platform is using edx-completion==2.0.0

It seems like that completion-aggregator is using an older version of edx-completion. The version is pinned here.

As we are rebasing to ironwood release so we should look into completion-aggregator to find out if we can upgrade the dependant version of edx-completion to make it compatible with ironwood. 

**JIRA:** https://openedx.atlassian.net/browse/YONK-1515

**Merge deadline:** Early next sprint

**Testing instructions:**

1. install openedx-completion-aggregator
2. Check if progress updating for courses.

**Reviewers:**
- [ ] @xitij2000 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

