### PR TITLE
[BB-2271] Convert course_key to string for mark_all_stale.delay

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.1.0] - 2020-04-17
+~~~~~~~~~~~~~~~~~~~~
+
+* Convert `course_key` to string before sending it to Celery task.
+
 [1.0.0] - 2018-01-04
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/signals.py
+++ b/completion_aggregator/signals.py
@@ -4,6 +4,7 @@ Handlers for signals emitted by block completion models.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+
 import six
 
 from django.conf import settings

--- a/completion_aggregator/signals.py
+++ b/completion_aggregator/signals.py
@@ -4,6 +4,7 @@ Handlers for signals emitted by block completion models.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
+import six
 
 from django.conf import settings
 from django.db.models.signals import post_save
@@ -64,8 +65,8 @@ def item_deleted_handler(usage_key, user_id, **kwargs):
     # Ordinarily we have to worry about losing course run information when
     # extracting a course_key from a usage_key, but the item_delete signal is
     # only fired from split-mongo, so it will always contain the course run.
-    course_key = usage_key.course_key
-    handler_tasks.mark_all_stale.delay(course_key=course_key)
+    course_str = six.text_type(usage_key.course_key)
+    handler_tasks.mark_all_stale.delay(course_key=course_str)
 
 
 def course_published_handler(course_key, **kwargs):
@@ -73,7 +74,8 @@ def course_published_handler(course_key, **kwargs):
     Update aggregators when a general course change happens.
     """
     log.debug("Updating aggregators due to course_published signal")
-    handler_tasks.mark_all_stale.delay(course_key=course_key)
+    course_str = six.text_type(course_key)
+    handler_tasks.mark_all_stale.delay(course_key=course_str)
 
 
 def cohort_updated_handler(user, course_key, **kwargs):
@@ -81,7 +83,8 @@ def cohort_updated_handler(user, course_key, **kwargs):
     Update aggregators for a user when the user changes cohort or enrollment track.
     """
     log.debug("Updating aggregators due to cohort or enrollment update signal")
-    handler_tasks.mark_all_stale.delay(course_key=course_key, users=[user])
+    course_str = six.text_type(course_key)
+    handler_tasks.mark_all_stale.delay(course_key=course_str, users=[user])
 
 
 def completion_updated_handler(signal, sender, instance, created, raw, using, update_fields, **kwargs):

--- a/completion_aggregator/tasks/handler_tasks.py
+++ b/completion_aggregator/tasks/handler_tasks.py
@@ -5,9 +5,9 @@ Tasks used in processing signal handlers.
 import six
 from celery import shared_task
 from celery_utils.logged_task import LoggedTask
+from opaque_keys.edx.keys import CourseKey
 
 from django.conf import settings
-from opaque_keys.edx.keys import CourseKey
 
 from ..batch import perform_aggregation
 from ..cachegroup import CacheGroup

--- a/completion_aggregator/tasks/handler_tasks.py
+++ b/completion_aggregator/tasks/handler_tasks.py
@@ -7,6 +7,7 @@ from celery import shared_task
 from celery_utils.logged_task import LoggedTask
 
 from django.conf import settings
+from opaque_keys.edx.keys import CourseKey
 
 from ..batch import perform_aggregation
 from ..cachegroup import CacheGroup
@@ -20,6 +21,8 @@ def mark_all_stale(course_key, users=None):
     Mark the specified enrollments as stale for all blocks.
     """
     users = users or get_active_users(course_key)
+    if isinstance(course_key, six.text_type):
+        course_key = CourseKey.from_string(course_key)
     stale_objects = [StaleCompletion(username=user.username, course_key=course_key, force=True) for user in users]
     StaleCompletion.objects.bulk_create(stale_objects, batch_size=1000)
     CacheGroup().delete_group(six.text_type(course_key))

--- a/completion_aggregator/tasks/handler_tasks.py
+++ b/completion_aggregator/tasks/handler_tasks.py
@@ -20,9 +20,9 @@ def mark_all_stale(course_key, users=None):
     """
     Mark the specified enrollments as stale for all blocks.
     """
-    users = users or get_active_users(course_key)
     if isinstance(course_key, six.text_type):
         course_key = CourseKey.from_string(course_key)
+    users = users or get_active_users(course_key)
     stale_objects = [StaleCompletion(username=user.username, course_key=course_key, force=True) for user in users]
     StaleCompletion.objects.bulk_create(stale_objects, batch_size=1000)
     CacheGroup().delete_group(six.text_type(course_key))


### PR DESCRIPTION
**Description:** Prevents issues when signal handlers receive CourseLocators instead of string, as these are passed to Celery tasks and fail JSON serialisation.

**JIRA:** BB-2271

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** ASAP

**Testing instructions:** Check related PR

**Reviewers:**
- [x] @Agrendalath 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** None