### PR TITLE
[BB-2296] Fix course conversion in `reaggregate_course` management command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.1.3] - 2020-05-08
+~~~~~~~~~~~~~~~~~~~~
+
+* Fix `all` option in `reaggregate_course`.
+
 [2.1.1] - 2020-04-20
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '2.1.2'
+__version__ = '2.1.3'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/management/commands/reaggregate_course.py
+++ b/completion_aggregator/management/commands/reaggregate_course.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
+import six
 from opaque_keys.edx.keys import CourseKey
 
 from django.core.management.base import BaseCommand
@@ -59,8 +60,9 @@ class Command(BaseCommand):
         if options['all']:
             options['course_keys'] = BlockCompletion.objects.values_list('course_key').distinct()
         CourseEnrollment = compat.course_enrollment_model()  # pylint: disable=invalid-name
-        for course_str in options['course_keys']:
-            course = CourseKey.from_string(course_str)
+        for course in options['course_keys']:
+            if isinstance(course, six.string_types):
+                course = CourseKey.from_string(course)
             all_enrollments = CourseEnrollment.objects.filter(course=course).select_related('user')
             StaleCompletion.objects.bulk_create(
                 (

--- a/completion_aggregator/tasks/handler_tasks.py
+++ b/completion_aggregator/tasks/handler_tasks.py
@@ -20,7 +20,7 @@ def mark_all_stale(course_key, users=None):
     """
     Mark the specified enrollments as stale for all blocks.
     """
-    if isinstance(course_key, six.text_type):
+    if isinstance(course_key, six.string_types):
         course_key = CourseKey.from_string(course_key)
     usernames = users or [user.username for user in get_active_users(course_key)]
     stale_objects = [StaleCompletion(username=username, course_key=course_key, force=True) for username in usernames]


### PR DESCRIPTION
**Description:** This fixes running aggregator for all courses by disabling the `CourseKey.from_string` casting for non-string objects.

**JIRA:** [BB-2296](https://tasks.opencraft.com/browse/BB-2296)

**Merge deadline:** as soon as possible

**Testing instructions:**

1. Install aggregator from this branch.
1. Run aggregator for all courses `/edx/bin/manage.edxapp lms reaggregate_course -a`. It should not break.
1. (Optionally) run aggregator for demo course: `/edx/bin/manage.edxapp lms reaggregate_course -c course-v1:edX+DemoX+Demo_Course`.

**Reviewers:**
- [x] @viadanna 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] <s>Documentation updated (not only docstrings)</s> (this is a bug fix)
- [x] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)