### PR TITLE
fix completion submission for old mongo keys

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/api/v0/views.py
+++ b/completion_aggregator/api/v0/views.py
@@ -426,6 +426,10 @@ class CompletionBlockUpdateView(CompletionViewMixin, APIView):
         except (InvalidKeyError, compat.get_item_not_found_error()):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
+        if block_key.course_key.run is None:
+            # Old mongo keys must be annotated with course run info before calling submit_completion
+            block_key = block_key.replace(course_key=course_key)
+
         _, created = BlockCompletion.objects.submit_completion(
             user=request.user,
             block_key=block_key,


### PR DESCRIPTION
**Description:** In Juniper [completion submission](https://github.com/edx/completion/blob/3.2.0/completion/models.py#L91..L96) (edx-completion==3.2.0) expects Old mongo 
 block keys to be annotated with course run info before other wise it throws exception linked above. This PR adds course info in completion api before submission.

**JIRA:** https://edx-wiki.atlassian.net/browse/MCKIN-29363

**Dependencies:** None. 

**Merge deadline:** ASAP

**Testing instructions:**

1. Create a course using old mongo(DraftModuleStore)
2. Add html block to the course
3. Do post request to the API `http://edx.devstack.lms:18000/api/completion/v0/<course_id>/blocks/<old mongo block id>/`
4. Server will respond with 500.
5. After applying above fix it should not through exception and update the progress.

**Reviewers:**
- [ ] @xitij2000  

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
