### PR TITLE
Fix Django version check

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/utils.py
+++ b/completion_aggregator/utils.py
@@ -6,9 +6,6 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.utils.translation import ugettext as _
 
-DJANGO_MAJOR_VERSION = django.VERSION[0]
-DJANGO_MINOR_VERSION = django.VERSION[1]
-
 WAFFLE_AGGREGATE_STALE_FROM_SCRATCH = 'completion_aggregator.aggregate_stale_from_scratch'
 
 
@@ -44,7 +41,7 @@ def make_datetime_timezone_unaware(date):
     # pylint: disable=line-too-long
     # Ref: https://github.com/django/django/commit/e707e4c709c2e3f2dad69643eb838f87491891f8#diff-af003fcfed7cfbdeb396f8647ed0f92fR258
     # pylint: enable=line-too-long
-    if DJANGO_MAJOR_VERSION >= 1 and DJANGO_MINOR_VERSION >= 10:
+    if django.VERSION >= (1, 10):
         date = date.astimezone(timezone.utc).replace(tzinfo=None)
     return date
 

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -6,7 +6,7 @@ Tests for the `openedx-completion-aggregator` utils module.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import ddt
@@ -51,5 +51,5 @@ class MakeTimeZoneUnawareTestCase(TestCase):
     )
     def test_make_datetime_timezone_unaware(self, version):
         with patch('django.VERSION', version):
-            date = make_datetime_timezone_unaware(datetime.now())
+            date = make_datetime_timezone_unaware(datetime.now(timezone.utc))
             assert date.tzinfo is None

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -6,12 +6,15 @@ Tests for the `openedx-completion-aggregator` utils module.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from datetime import datetime
+from unittest.mock import patch
+
 import ddt
 import pytest
 
 from django.test import TestCase
 
-from completion_aggregator.utils import get_percent
+from completion_aggregator.utils import get_percent, make_datetime_timezone_unaware
 
 
 @ddt.ddt
@@ -32,3 +35,21 @@ class GetPercentTestCase(TestCase):
     def test_get_percent_with_valid_values(self, earned, possible, expected_percentage):
         percentage = get_percent(earned, possible)
         self.assertEqual(percentage, expected_percentage)
+
+
+@ddt.ddt
+class MakeTimeZoneUnawareTestCase(TestCase):
+    """
+    Tests of the `make_datetime_timezone_unaware` function
+    """
+
+    @ddt.data(
+        (1, 9, 13),
+        (1, 10, 'a1'),
+        (1, 10),
+        (2, 0, 'a1'),
+    )
+    def test_make_datetime_timezone_unaware(self, version):
+        with patch('django.VERSION', version):
+            date = make_datetime_timezone_unaware(datetime.now())
+            assert date.tzinfo is None

--- a/tests/test_util_functions.py
+++ b/tests/test_util_functions.py
@@ -44,10 +44,10 @@ class MakeTimeZoneUnawareTestCase(TestCase):
     """
 
     @ddt.data(
-        (1, 9, 13),
         (1, 10, 'a1'),
         (1, 10),
         (2, 0, 'a1'),
+        (2, 2),
     )
     def test_make_datetime_timezone_unaware(self, version):
         with patch('django.VERSION', version):


### PR DESCRIPTION
**Description:** Fixes the Django version check for timezones.

**Merge deadline:** ASAP

**Testing instructions:**

1. Create a virtualenv and install the test requirements.
2. Install "Django>=2" inside the virtualenv.
3. Using a shell, call the [make_datetime_timezone_unaware](https://github.com/open-craft/openedx-completion-aggregator/blob/master/completion_aggregator/utils.py#L40) function with a date and confirm the resulting date is timezone-unaware.
Optional: Repeat steps 2-3 using other Django versions built after [this commit](https://github.com/django/django/commit/e707e4c709c2e3f2dad69643eb838f87491891f8#diff-af003fcfed7cfbdeb396f8647ed0f92fR258).

**Reviewers:**
- [ ] @0x29a 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
