### PR TITLE
MCKIN-30345: fix aggregator incorrect  modified date

### DIFF
--- a/completion_aggregator/__init__.py
+++ b/completion_aggregator/__init__.py
@@ -4,6 +4,6 @@ an app that aggregates block level completion data for different block types for
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '3.0.2'
+__version__ = '3.0.3'
 
 default_app_config = 'completion_aggregator.apps.CompletionAggregatorAppConfig'  # pylint: disable=invalid-name

--- a/completion_aggregator/core.py
+++ b/completion_aggregator/core.py
@@ -269,6 +269,7 @@ class AggregationUpdater(object):
                     possible=total_possible,
                     percent=percent,
                     last_modified=last_modified,
+                    modified=timezone.now(),
                 )
                 self.aggregators[block] = aggregator
             else:


### PR DESCRIPTION
**Description:** Modified date for Aggregator is being set incorrectly(in the past). The issue is happening because in Juniper release model_utils have been upgraded to version 4.0.0 from version 3.0.0 in ironwood. This new version adds [this method](https://github.com/jazzband/django-model-utils/blob/4.0.0/model_utils/fields.py#L32) which populates the modified field default value when aggregator model instance is created the first time and uses the same for all instances. Because model instances are not saved(only values are extracted for raw query) [field pre_save](https://github.com/jazzband/django-model-utils/blob/4.0.0/model_utils/fields.py#L38) is never called and the same date is used for all instances until the model field object is destroyed and recreated. This PR sets the modified field of Aggregator manually.

**JIRA:** https://edx-wiki.atlassian.net/browse/MCKIN-30345

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Merge deadline:** ASAP

**Installation instructions:** List any non-trivial installation 
instructions.

**Reviewers:**
- [ ] @viadanna  
- [ ] @xitij2000 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
