### PR TITLE
[SE-5145] Fix completion progress bar error when user not enrolled in course

### DIFF
--- a/completion_aggregator/views.py
+++ b/completion_aggregator/views.py
@@ -9,7 +9,6 @@ from django.db import transaction
 from django.shortcuts import render
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import TemplateView
-from rest_framework import status
 from xblockutils.resources import ResourceLoader
 
 from .api.v1.views import CompletionDetailView
@@ -35,7 +34,7 @@ class CompletionProgressBarView(LoginRequiredMixin, TemplateView):
         with transaction.atomic():
             completion_resp = CompletionDetailView.as_view()(request, course_key)
 
-        if completion_resp.response_code == status.HTTP_200_OK:
+        if completion_resp.data:
             results = completion_resp.data.get('results')
             user_completion_percentage = self._get_user_completion(chapter_id, results)
 

--- a/completion_aggregator/views.py
+++ b/completion_aggregator/views.py
@@ -32,10 +32,10 @@ class CompletionProgressBarView(LoginRequiredMixin, TemplateView):
             new_req['requested_fields'] = "chapter"
         request.GET = new_req
         with transaction.atomic():
-            completion_resp = CompletionDetailView.as_view()(request, course_key)
+            completion_resp = CompletionDetailView.as_view()(request, course_key).data
 
-        if completion_resp.data:
-            results = completion_resp.data.get('results')
+        if completion_resp:
+            results = completion_resp.get('results')
             user_completion_percentage = self._get_user_completion(chapter_id, results)
 
             if user_completion_percentage:


### PR DESCRIPTION
**Description: **

This PR fixes an error where completion progress bar raises a TransactionManagementError 
if a user is not enrolled in a course.

The CompletionDetailView raises an 404 if it is unable to calculation
the completion details for a specific user/course
combination (eg. the user isn't enrolled in the course).

CompletionProgressBarView calls this view to determine the percentage
to show to a learner.

A 404 in the main transaction, causes it to be rolled back, hence any
further db calls will break with the error.

> django.db.transaction.TransactionManagementError: An error occurred
in the current transaction. You can't execute queries until the end of
the 'atomic' block.

The change in this commit wraps the offending code in another
transaction so that the inner transaction is rolled back rather than
the main one.

**JIRA:** https://tasks.opencraft.com/projects/SE/issues/SE-5145

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

As a newly created student, open the URL. http://localhost:18000/completion-aggregator/progress_bar/course-v1:edX+DemoX+Demo_Course/

Before merging the PR, there will be an error in the Django logs.

**Reviewers:**
- @pkulkark

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)