### PR TITLE
feat: add tracking logs

### DIFF
--- a/completion_aggregator/models.py
+++ b/completion_aggregator/models.py
@@ -186,11 +186,11 @@ class AggregatorManager(models.Manager):
             updated_aggregators: List of Aggregator intances
 
         """
-        for obj in updated_aggregators:
-            event = "progress" if obj.percent < 1 else "completion"
-            event_type = obj.aggregation_name
+        for aggregator in updated_aggregators:
+            event = "progress" if aggregator.percent < 1 else "completion"
+            event_type = aggregator.aggregation_name
 
-            if event_type not in settings.ALLOWED_COMPLETION_AGGREGATOR_EVENT_TYPES.get(event, []):
+            if event_type not in settings.ALLOWED_COMPLETION_AGGREGATOR_EVENT_TYPES.get(event, {}):
                 continue
 
             event_name = f"edx.completion_aggregator.{event}.{event_type}"
@@ -198,14 +198,14 @@ class AggregatorManager(models.Manager):
             tracker.emit(
                 event_name,
                 {
-                    "user_id": obj.user_id,
-                    "course_id": str(obj.course_key),
-                    "block_id": str(obj.block_key),
-                    "modified": obj.modified,
-                    "created": obj.created,
-                    "earned": obj.earned,
-                    "possible": obj.possible,
-                    "percent": obj.percent,
+                    "user_id": aggregator.user_id,
+                    "course_id": str(aggregator.course_key),
+                    "block_id": str(aggregator.block_key),
+                    "modified": aggregator.modified,
+                    "created": aggregator.created,
+                    "earned": aggregator.earned,
+                    "possible": aggregator.possible,
+                    "percent": aggregator.percent,
                     "type": event_type,
                 }
             )

--- a/completion_aggregator/settings/common.py
+++ b/completion_aggregator/settings/common.py
@@ -13,18 +13,18 @@ def plugin_settings(settings):
     # This setting controls which type of event will be published to change the default behavior
     # the block type should be removed or added from the progress or completion list.
     settings.ALLOWED_COMPLETION_AGGREGATOR_EVENT_TYPES = {
-        "progress": [
+        "progress": {
             "course",
             "chapter",
             "sequential",
             "vertical",
-        ],
-        "completion": [
+        },
+        "completion": {
             "course",
             "chapter",
             "sequential",
             "vertical",
-        ]
+        }
     }
     settings.COMPLETION_AGGREGATOR_BLOCK_TYPES = {
         'course',

--- a/completion_aggregator/settings/common.py
+++ b/completion_aggregator/settings/common.py
@@ -9,6 +9,23 @@ def plugin_settings(settings):
     """
     Modify the provided settings object with settings specific to this plugin.
     """
+    # Emit feature allows to publish two kind of events progress and completion
+    # This setting controls which type of event will be published to change the default behavior
+    # the block type should be removed or added from the progress or completion list.
+    settings.ALLOWED_COMPLETION_AGGREGATOR_EVENT_TYPES = {
+        "progress": [
+            "course",
+            "chapter",
+            "sequential",
+            "vertical",
+        ],
+        "completion": [
+            "course",
+            "chapter",
+            "sequential",
+            "vertical",
+        ]
+    }
     settings.COMPLETION_AGGREGATOR_BLOCK_TYPES = {
         'course',
         'chapter',

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,5 +9,6 @@ django-model-utils    # Provides TimeStampedModel abstract base class
 edx-opaque-keys    # Provides CourseKey and UsageKey
 edx-completion
 edx-toggles
+event-tracking
 six
 XBlock[django]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -113,7 +113,9 @@ edx-toggles==5.1.0
     #   -r requirements/base.in
     #   edx-completion
 event-tracking==2.2.0
-    # via edx-completion
+    # via
+    #   -r requirements/base.in
+    #   edx-completion
 fs==2.4.16
     # via
     #   fs-s3fs

--- a/test_settings.py
+++ b/test_settings.py
@@ -18,6 +18,20 @@ def root(*args):
     return join(abspath(dirname(__file__)), *args)
 
 
+ALLOWED_COMPLETION_AGGREGATOR_EVENT_TYPES = {
+    "progress": [
+        "course",
+        "chapter",
+        "sequential",
+        "vertical",
+    ],
+    "completion": [
+        "course",
+        "chapter",
+        "sequential",
+        "vertical",
+    ]
+}
 AUTH_USER_MODEL = 'auth.User'
 CELERY_ALWAYS_EAGER = True
 COMPLETION_AGGREGATOR_BLOCK_TYPES = {'course', 'chapter', 'sequential'}
@@ -53,6 +67,7 @@ INSTALLED_APPS = (
     'oauth2_provider',
     'waffle',
     'test_utils.test_app',
+    'eventtracking.django.apps.EventTrackingConfig',
 )
 
 LOCALE_PATHS = [root('completion_aggregator', 'conf', 'locale')]
@@ -80,6 +95,8 @@ TEMPLATES = [
     },
 ]
 USE_TZ = True
+
+EVENT_TRACKING_ENABLED = True
 
 # pylint: disable=unused-import,wrong-import-position
 from test_utils.test_app import celery  # isort:skip


### PR DESCRIPTION
**Description:** 
This changes allow to emit events when an aggregator is created or updated,  and basically I'm proposing this to integrate those new events with the  [event-routing-backends](https://github.com/openedx/event-routing-backends/tree/master) library, which takes advantages of the tracking events to publish that data to a Xapi or caliper service. The default behavior that I'm proposing has the following events

Progress events, those will be emitted  when the block has not reached the  100% of completion
-  `edx.completion_aggregator.progress.course`
- `edx.completion_aggregator.progress.chapter`
- `edx.completion_aggregator.progress.sequential`
- `edx.completion_aggregator.progress.vertical`

Completion events, those will be emitted when the block has reached the 100% of completion

-  `edx.completion_aggregator.completion.course`
- `edx.completion_aggregator.completion.chapter`
- `edx.completion_aggregator.completion.sequential`
- `edx.completion_aggregator.completion.vertical`

**Testing instructions:**

1. Create a section with a subsection and a unit
2. Complete the unit
3. Check server logs

![image](https://github.com/nelc/openedx-completion-aggregator/assets/36200299/deb8614a-e303-4822-ad78-8469812735f6)

**Reviewers:**
- [x] tag reviewer @Agrendalath 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
